### PR TITLE
Revert "removes GCR stack coordinates"

### DIFF
--- a/content/docs/stacks/_index.md
+++ b/content/docs/stacks/_index.md
@@ -28,6 +28,9 @@ index.docker.io/paketobuildpacks/build:tiny-cnb
 {{< code/copyable >}}
 index.docker.io/paketobuildpacks/run:tiny-cnb
 {{< /code/copyable >}}
+{{< code/copyable >}}
+gcr.io/paketo-buildpacks/run:tiny-cnb
+{{< /code/copyable >}}
 
 #### Contains:
 * Build: ubuntu:bionic + openssl + CA certs + compilers + shell utilities
@@ -43,6 +46,9 @@ index.docker.io/paketobuildpacks/build:base-cnb
 {{< code/copyable >}}
 index.docker.io/paketobuildpacks/run:base-cnb
 {{< /code/copyable >}}
+{{< code/copyable >}}
+gcr.io/paketo-buildpacks/run:base-cnb
+{{< /code/copyable >}}
 
 #### Contains:
 * Build: ubuntu:bionic + openssl + CA certs + compilers + shell utilities
@@ -57,6 +63,9 @@ index.docker.io/paketobuildpacks/build:full-cnb
 #### Run Images
 {{< code/copyable >}}
 index.docker.io/paketobuildpacks/run:full-cnb
+{{< /code/copyable >}}
+{{< code/copyable >}}
+gcr.io/paketo-buildpacks/run:full-cnb
 {{< /code/copyable >}}
 
 #### Contains:


### PR DESCRIPTION
This reverts commit f08b6f8e0ef78f8e31525d184c8dee3600ca6802.

This was removed by accident. The Paketo Run Images will continue to be published to GCR because it creates faster builds for people who are publishing their app images to GCR. 