### PR TITLE
Fix naming inconsistency

### DIFF
--- a/content/docs/buildpacks/language-family-buildpacks/nodejs.md
+++ b/content/docs/buildpacks/language-family-buildpacks/nodejs.md
@@ -79,10 +79,9 @@ of a `.nvmrc` file, see [.nvmrc](https://github.com/nvm-sh/nvm#nvmrc) in the
 Node Version Manager repository on GitHub.
 
 ### Using .node-version
-`.node-version` is another common option for managing an app's Node.js version,
-that is compatible with common NodeJS version managers such as `asdf` and `nodenv`.
-You can use a`.node-version` file to set the Node.js version that your apps use
-during deployment, according to one of the following formats:
+`.node-version` is another common option that is compatible with Node.js version managers
+such as `asdf` and `nodenv`. You can use a `.node-version` file to set the Node.js version
+that your apps use during deployment, according to one of the following formats:
 
 {{< code/copyable >}}
 12.12.0


### PR DESCRIPTION
## Summary
In my last docs PR, I referred to `Node.js` as `NodeJS`, which is inconsistent with the rest of the `Node.js Buildpack` docs. Figured worth a small PR to fix! 

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
