### PR TITLE
Add docs for using CA certificates in Node.js

### DIFF
--- a/content/docs/buildpacks/language-family-buildpacks/nodejs.md
+++ b/content/docs/buildpacks/language-family-buildpacks/nodejs.md
@@ -196,23 +196,16 @@ mentioned above.
 ## Using CA Certificates
 Users can provide their own CA certificates and have them included in the
 container root truststore at build-time and runtime using the [CA Certificates
-CNB](https://github.com/paketo-buildpacks/ca-certificates).
+CNB](https://github.com/paketo-buildpacks/ca-certificates). Check out the
+[docs](https://paketo.io/docs/buildpacks/configuration/#ca-certificates) for
+how to enable this.
 
-To enable this behavior, the app should contain:
-- a binding of `type` `ca-certificates` and
-- each provided certificate in the binding should contain one PEM encoded CA
-  certificate.
+### Node.js Specific Settings
+On top of the configurations mentioned in the CA Certificate docs, the
+`NODE_OPTIONS` environment variable must be set to `--use-openssl-ca`. This
+ensures that the `node` process will utilize the newly added CA certificate.
 
-Check out the [CA Certificates
-README](https://github.com/paketo-buildpacks/ca-certificates/blob/main/README.md)
-for more information about app set configuration.
-
-### CA Certificates at runtime
-To use CA certificates at runtime, the `SERVICE_BINDING_ROOT` and
-`NODE_OPTIONS` environment variables must be set, as well as a volume mount for
-the bindings.  The `NODE_OPTIONS=--use-openssl-ca` argument is especially
-necessary for `node` to utilize the new CA.
-
+The final command to run a container with CA certificates will look like the following:
 {{< code/copyable >}}
 docker run \
   -it -p 8080:8080 --env PORT=8080 \

--- a/content/docs/buildpacks/language-family-buildpacks/nodejs.md
+++ b/content/docs/buildpacks/language-family-buildpacks/nodejs.md
@@ -193,6 +193,36 @@ deprecated in Node Engine Buildpack v1.0.0. To migrate from using
 `buildpack.yml` please set the `BP_NODE_OPTIMIZE_MEMORY` environment variable
 mentioned above.
 
+## Using CA Certificates
+Users can provide their own CA certificates and have them included in the
+container root truststore at build-time and runtime using the [CA Certificates
+CNB](https://github.com/paketo-buildpacks/ca-certificates).
+
+To enable this behavior, the app should contain:
+- a binding of `type` `ca-certificates` and
+- each provided certificate in the binding should contain one PEM encoded CA
+  certificate.
+
+Check out the [CA Certificates
+README](https://github.com/paketo-buildpacks/ca-certificates/blob/main/README.md)
+for more information about app set configuration.
+
+### CA Certificates at runtime
+To use CA certificates at runtime, the `SERVICE_BINDING_ROOT` and
+`NODE_OPTIONS` environment variables must be set, as well as a volume mount for
+the bindings.  The `NODE_OPTIONS=--use-openssl-ca` argument is especially
+necessary for `node` to utilize the new CA.
+
+{{< code/copyable >}}
+docker run \
+  -it -p 8080:8080 --env PORT=8080 \
+  --env SERVICE_BINDING_ROOT=/bindings \
+  --env NODE_OPTIONS="--use-openssl-ca" \
+  --volume "my-app/binding:/bindings/ca-certificates" \
+  my-app
+{{< /code/copyable >}}
+
+
 ## Node Start Command
 The Node.js CNB allows you to build a Node.js app that does not rely on any
 external packages. To detect whether for not the app is a Node.js app the


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds documentation for using CA Certificates with the Node.js buildpack

## Use Cases
<!-- An explanation of the use cases your change enables -->

With the implementation of https://github.com/paketo-buildpacks/nodejs/issues/308 we should document how to use the CA Certificates CNB.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
