### PR TITLE
add basic links for utility buildpacks in Node.js

### DIFF
--- a/content/docs/buildpacks/language-family-buildpacks/nodejs.md
+++ b/content/docs/buildpacks/language-family-buildpacks/nodejs.md
@@ -350,6 +350,22 @@ The Node.js CNB also supports simple apps that do not require third-party packag
 If no package manager is detected, the Node.js CNB will set the start command
 `node server.js`. The app name is ___not___ currently configurable.
 
+## Other Utilities
+The Node.js CNB also includes some utility buildpacks for use:
+
+### Procfile CNB
+This buildpack turns the contents of a Procfile into process types.
+Check out the [docs](https://paketo.io/docs/buildpacks/configuration/#procfiles) for how to use this buildpack.
+
+### Environment Variables CNB
+This buildpack embeds environment variables into an image.  Check out the
+[docs](https://github.com/paketo-buildpacks/environment-variables/blob/main/README.md)
+for how to use this buildpack.
+
+### Image Labels CNB
+This buildpack enables configuration of labels on the created image.
+Check out the [docs](https://paketo.io/docs/buildpacks/configuration/#applying-custom-labels) for how to use this buildpack.
+
 ## Stack support
 The Node.js Buildpack runs fine on the Base builder for most apps. If your app
 requires compilation of native extensions using `node-gyp`, the buildpack requires that

--- a/content/docs/buildpacks/language-family-buildpacks/nodejs.md
+++ b/content/docs/buildpacks/language-family-buildpacks/nodejs.md
@@ -350,21 +350,27 @@ The Node.js CNB also supports simple apps that do not require third-party packag
 If no package manager is detected, the Node.js CNB will set the start command
 `node server.js`. The app name is ___not___ currently configurable.
 
-## Other Utilities
-The Node.js CNB also includes some utility buildpacks for use:
 
-### Procfile CNB
-This buildpack turns the contents of a Procfile into process types.
-Check out the [docs](https://paketo.io/docs/buildpacks/configuration/#procfiles) for how to use this buildpack.
+## Using a Procfile
+The Node.js CNB includes the [Procfile
+CNB](https://github.com/paketo-buildpacks/procfile). This buildpack turns the
+contents of a Procfile into process types.  Check out the
+[docs](https://paketo.io/docs/buildpacks/configuration/#procfiles) for
+information on how to use this buildpack.
 
-### Environment Variables CNB
-This buildpack embeds environment variables into an image.  Check out the
+## Adding Environment Variables to the Build/Run Image
+The Node.js CNB includes the [Environment Variables
+CNB](https://github.com/paketo-buildpacks/environment-variables). This
+buildpack embeds environment variables into an image.  Check out the
 [docs](https://github.com/paketo-buildpacks/environment-variables/blob/main/README.md)
-for how to use this buildpack.
+for information on how to use this buildpack.
 
-### Image Labels CNB
-This buildpack enables configuration of labels on the created image.
-Check out the [docs](https://paketo.io/docs/buildpacks/configuration/#applying-custom-labels) for how to use this buildpack.
+## Adding Image Labels to the Build/Run Image
+The Node.js CNB includes the [Image Labels
+CNB](https://github.com/paketo-buildpacks/image-labels).This buildpack enables
+configuration of labels on the created image.  Check out the
+[docs](https://paketo.io/docs/buildpacks/configuration/#applying-custom-labels)
+for information on how to use this buildpack.
 
 ## Stack support
 The Node.js Buildpack runs fine on the Base builder for most apps. If your app


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds super basic information about the "utility" buildpacks available in the Node.js buildpack. It just mentions what's available, and where the docs can be found.

## Use Cases
<!-- An explanation of the use cases your change enables -->

We don't document anywhere which utilities are available in our buildpacks. A user shouldn't have to look at the `buildpack.toml` to learn what buildpacks are available. This section just makes it easier for users to find documentation on these utilities.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
