### PR TITLE
updates CSS to add opacity to all links

### DIFF
--- a/assets/css/paketo.css
+++ b/assets/css/paketo.css
@@ -40,6 +40,9 @@ a {
 	background: transparent;
 	color: inherit;
 }
+a:hover {
+	opacity: .7;
+}
 ins {
 	background-color: #ff9;
 	color: #000;
@@ -376,10 +379,6 @@ nav a, .cta, .docs-body a {
 	padding: 8px 16px;
 	border-radius: 4px;
 }
-.external-link:hover {
-	background: #489ebc;
-	color: white;
-}
 .nav-opener {
 	position: fixed;
 	backface-visibility: hidden;
@@ -452,9 +451,6 @@ nav a, .cta, .docs-body a {
 	flex-flow: row wrap;
 	justify-content: space-evenly;
 	align-items: center;
-}
-.hero a.logo:hover {
-	opacity: 0.5;
 }
 .hero .logos .logo {
 	flex-basis: 33.33%;
@@ -657,9 +653,7 @@ footer p {
 .docs-body {
 	width: calc(100% - 380px);
 }
-.docs-body a:hover{
-	opacity: 0.5;
-}
+
 .docs-lastmod {
 	padding-left: 50px;
 	font-style: italic;


### PR DESCRIPTION
closes https://github.com/paketo-buildpacks/paketo-website/issues/114

@ForestEckhardt this reduces some of the opacity changes you made recently and also applies it to all links. Reason being, I felt it's a little weird that certain links don't get lighter when hovered over and I feel we should be consistent. 

