### PR TITLE
remove extra CA cert docs from node.js

### DIFF
--- a/content/docs/buildpacks/language-family-buildpacks/nodejs.md
+++ b/content/docs/buildpacks/language-family-buildpacks/nodejs.md
@@ -193,29 +193,6 @@ deprecated in Node Engine Buildpack v1.0.0. To migrate from using
 `buildpack.yml` please set the `BP_NODE_OPTIMIZE_MEMORY` environment variable
 mentioned above.
 
-## Using CA Certificates
-Users can provide their own CA certificates and have them included in the
-container root truststore at build-time and runtime using the [CA Certificates
-CNB](https://github.com/paketo-buildpacks/ca-certificates). Check out the
-[docs](https://paketo.io/docs/buildpacks/configuration/#ca-certificates) for
-how to enable this.
-
-### Node.js Specific Settings
-On top of the configurations mentioned in the CA Certificate docs, the
-`NODE_OPTIONS` environment variable must be set to `--use-openssl-ca`. This
-ensures that the `node` process will utilize the newly added CA certificate.
-
-The final command to run a container with CA certificates will look like the following:
-{{< code/copyable >}}
-docker run \
-  -it -p 8080:8080 --env PORT=8080 \
-  --env SERVICE_BINDING_ROOT=/bindings \
-  --env NODE_OPTIONS="--use-openssl-ca" \
-  --volume "my-app/binding:/bindings/ca-certificates" \
-  my-app
-{{< /code/copyable >}}
-
-
 ## Node Start Command
 The Node.js CNB allows you to build a Node.js app that does not rely on any
 external packages. To detect whether for not the app is a Node.js app the
@@ -373,6 +350,12 @@ The Node.js CNB also supports simple apps that do not require third-party packag
 If no package manager is detected, the Node.js CNB will set the start command
 `node server.js`. The app name is ___not___ currently configurable.
 
+## Using CA Certificates
+Users can provide their own CA certificates and have them included in the
+container root truststore at build-time and runtime using the [CA Certificates
+CNB](https://github.com/paketo-buildpacks/ca-certificates). Check out the
+[docs](https://paketo.io/docs/buildpacks/configuration/#ca-certificates) for
+how to enable this.
 
 ## Using a Procfile
 The Node.js CNB includes the [Procfile


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

It turns out `NODE_OPTIONS=--use-openssl-ca` is not necessary to use when using the CA Certificates buildpack with Node.js since the binary is compiled with an option that sets OpenSSL as the default store.

This PR removes docs from the Node.js page that talk about this, and moves the CA cert section to the bottom of the docs with the other utility buildpack documentation.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Keeps docs up to date.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
