### PR TITLE
Fix default-builder config recommendation

### DIFF
--- a/content/docs/buildpacks/configuration.md
+++ b/content/docs/buildpacks/configuration.md
@@ -39,7 +39,7 @@ The [pack CLI][pack] is used throughout the examples. `pack` is just one of seve
 
 Examples assume that the [Paketo Base builder][base builder] is the default builder:
 {{< code/copyable >}}
-pack set-default-builder paketobuildpacks/builder:base
+pack config default-builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
 ## Types of Configuration

--- a/content/docs/buildpacks/language-family-buildpacks/java-native-image.md
+++ b/content/docs/buildpacks/language-family-buildpacks/java-native-image.md
@@ -39,7 +39,7 @@ The [pack CLI][pack] is used throughout the examples. `pack` is just one of seve
 
 Examples assume that either the [Paketo Tiny][tiny builder] or [Paketo Base builder][base builder] is the default builder:
 {{< code/copyable >}}
-pack set-default-builder paketobuildpacks/builder:tiny
+pack config default-builder paketobuildpacks/builder:tiny
 {{< /code/copyable >}}
 
 All java native image example images should return `{"status":"UP"}` from the [actuator health endpoint][spring boot actuator endpoints].

--- a/content/docs/buildpacks/language-family-buildpacks/java.md
+++ b/content/docs/buildpacks/language-family-buildpacks/java.md
@@ -56,7 +56,7 @@ The [pack CLI][pack] is used throughout the examples. `pack` is just one of seve
 
 Examples assume that the [Paketo Base builder][base builder] is the default builder:
 {{< code/copyable >}}
-pack set-default-builder paketobuildpacks/builder:base
+pack config default-builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
 All java example images should return `{"status":"UP"}` from the [actuator health endpoint][spring boot actuator endpoints].


### PR DESCRIPTION
## Summary
`set-default-builder` is deprecated, users who follow the docs get the following warning:
`Warning: Command pack set-default-builder has been deprecated, please use pack config default-builder instead`

## Use Cases
Not getting a deprecation warning while users follow the docs.

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
