### PR TITLE
update hugo modules on cron schedule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Hugo
       run: |
         mkdir -p build-environment/.bin
-        curl "https://github.com/gohugoio/hugo/releases/download/v0.80.0/hugo_extended_0.80.0_Linux-64bit.tar.gz" \
+        curl "https://github.com/gohugoio/hugo/releases/download/v0.82.0/hugo_extended_0.82.0_Linux-64bit.tar.gz" \
           --silent \
           --location \
           --output /tmp/hugo.tar.gz

--- a/.github/workflows/update-hugo-modules.yml
+++ b/.github/workflows/update-hugo-modules.yml
@@ -1,0 +1,59 @@
+name: Update Hugo Modules
+
+on:
+  schedule:
+  - cron: '*/15 * * * *'
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    name: Update Hugo Modules
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: main
+
+    - name: Install Hugo
+      run: |
+        mkdir -p .bin
+        curl "https://github.com/gohugoio/hugo/releases/download/v0.82.0/hugo_extended_0.82.0_Linux-64bit.tar.gz"\
+          --silent \
+          --location \
+          --output /tmp/hugo.tar.gz
+        tar -xOzvf /tmp/hugo.tar.gz 'hugo' > .bin/hugo
+        chmod +x .bin/hugo
+        rm /tmp/hugo.tar.gz
+
+    - name: Update Modules
+      run: |
+        .bin/hugo mod get -u ./...
+        .bin/hugo mod tidy
+        rm -rf .bin/
+
+    - name: Commit
+      id: commit
+      run: |
+        git config --global user.email "paketobuildpacks@gmail.com"
+        git config --global user.name "paketo-bot"
+
+        if [[ -n "$(git status --short)" ]]; then
+          git add --all .
+          git commit --message "Updating Hugo modules"
+          echo "::set-output name=commit_sha::$(git rev-parse HEAD)"
+        fi
+
+    - name: Push Branch
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+      with:
+        branch: automation/hugo-modules/update
+
+    - name: Open Pull Request
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        title: "Updates Hugo modules"
+        branch: automation/hugo-modules/update


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
update hugo modules on cron schedule because dependabot (apparently) doesn't support  updating indirect
dependencies in a go.mod

Also upgrades to hugo 0.82.0 to get the latest Hugo Modules features.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
