### PR TITLE
update-hugo-modules workflow: use paketo create-commit action

### DIFF
--- a/.github/workflows/update-hugo-modules.yml
+++ b/.github/workflows/update-hugo-modules.yml
@@ -39,15 +39,12 @@ jobs:
 
     - name: Commit
       id: commit
-      run: |
-        git config --global user.email "paketobuildpacks@gmail.com"
-        git config --global user.name "paketo-bot"
-
-        if [[ -n "$(git status --short)" ]]; then
-          git add --all .
-          git commit --message "Updating Hugo modules"
-          echo "::set-output name=commit_sha::$(git rev-parse HEAD)"
-        fi
+      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+      with:
+        message: "Updating Hugo modules"
+        pathspec: "."
+        keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
 
     - name: Push Branch
       if: ${{ steps.commit.outputs.commit_sha != '' }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Use the Paketo create-commit action instead of the bespoke `run:` script for that step. I'm hoping this alleviates [this failure](https://github.com/paketo-buildpacks/paketo-website/runs/2300797057?check_suite_focus=true) which seems to be caused by some sort of [file permissions issue](https://askubuntu.com/questions/1098856/failed-to-update-ref-head-lock-permission-denied) on the contents of the `.git` directory. I'm hoping that the root cause lies in some difference between the container that is used by default by the GHA runner and the one that is used to check out the branch. Hopefully bringing this workflow in line with something like the Paketo implementation buildpack [Github Config update workflow](https://github.com/paketo-buildpacks/github-config/blob/main/implementation/.github/workflows/update-github-config.yml) will address the problem.

## Use Cases
<!-- An explanation of the use cases your change enables -->
 I'm hoping this alleviates [this failure](https://github.com/paketo-buildpacks/paketo-website/runs/2300797057?check_suite_focus=true) 

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
