### PR TITLE
switch go.mod to track tag of dotnet core docs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/paketo-buildpacks/paketo-website
 
 go 1.16
 
-require github.com/paketo-buildpacks/dotnet-core/docs v0.0.0-20210413215956-fcea58e783b8 // indirect
+require github.com/paketo-buildpacks/dotnet-core/docs v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/paketo-buildpacks/dotnet-core/docs v0.0.0-20210413215956-fcea58e783b8 h1:ejLelkaBmmRwzWWq+catin7ywMdT91HzGIhISUQWMyw=
-github.com/paketo-buildpacks/dotnet-core/docs v0.0.0-20210413215956-fcea58e783b8/go.mod h1:zhHrJf9s3o4z9Rj/byD69R0YPDOdvDSe+iWjeE2gvI4=
+github.com/paketo-buildpacks/dotnet-core/docs v0.2.0 h1:RLKP4TjomEH0jtXhPGkZCVbdAlKf08pobTSG1BhmBEA=
+github.com/paketo-buildpacks/dotnet-core/docs v0.2.0/go.mod h1:zhHrJf9s3o4z9Rj/byD69R0YPDOdvDSe+iWjeE2gvI4=


### PR DESCRIPTION
instead of latest commit on main

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The `go.mod` has been updated to track a tagged version of the dotnet core hugo module
## Use Cases
<!-- An explanation of the use cases your change enables -->
The repo will no longer open pull requests for every commit to main in the dotnet-core language family repo.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
