### PR TITLE
document BP_GO_BUILD_LDFLAGS

### DIFF
--- a/content/docs/buildpacks/language-family-buildpacks/go.md
+++ b/content/docs/buildpacks/language-family-buildpacks/go.md
@@ -81,11 +81,30 @@ sets the following build flags:
 * `-buildmode=pie`
 * `-mod=vendor` (if there is a go.mod file in the app source code)
 
+### BP_GO_BUILD_FLAGS
 To set custom values for your build flags or override the defaults, assign a
-list of flags to the `BP_GO_BUILD_FLAGS` environment variable as shown below:
+list of flags to the `BP_GO_BUILD_FLAGS` environment variable at build time, either directly (ex. `pack build
+my-app --env BP_GO_BUILD_FLAGS="-buildmode=some-build-mode -tags=paketo,production"`) or through a
+[project.toml](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md)
+file:
 
 {{< code/copyable >}}
-BP_GO_BUILD_FLAGS=-buildmode=some-build-mode -tags=paketo,production -ldflags="-X main.variable=some-value" -race
+[[ build.env ]]
+  name = 'BP_GO_BUILD_FLAGS'
+  value = '-buildmode=some-build-mode -tags=paketo,production'
+{{< /code/copyable >}}
+
+### BP_GO_BUILD_LDFLAGS
+The Go CNB also allows users to configure the value of `-ldflags` for the `go build`
+command by setting the `BP_GO_BUILD_LDFLAGS` environment variable at build time, either directly (ex. `pack build
+my-app --env BP_GO_BUILD_LDFLAGS="-X main.variable=some-value"`) or through a
+[project.toml](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md)
+file:
+
+{{< code/copyable >}}
+[[ build.env ]]
+  name = 'BP_GO_BUILD_LDFLAGS'
+  value = '-X main.variable=some-value'
 {{< /code/copyable >}}
 
 ### Deprecated: Using buildpack.yml


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
As of Paketo Go buildpack [v0.6.0](https://github.com/paketo-buildpacks/go/releases/tag/v0.6.0), the buildpack supports `BP_GO_BUILD_LDFLAGS`. This PR adds documentation for that environment variable. It also improves the project.toml examples provided.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
