### PR TITLE
reorganize Go documentation

### DIFF
--- a/content/docs/howto/dotnet-core.md
+++ b/content/docs/howto/dotnet-core.md
@@ -4,6 +4,7 @@ weight: 302
 menu:
   main:
     parent: "howto"
+    name: ".Net Core"
 aliases:
   - /docs/buildpacks/language-family-buildpacks/dotnet-core/
 ---

--- a/content/docs/howto/go.md
+++ b/content/docs/howto/go.md
@@ -1,16 +1,15 @@
 ---
-title: "Go Buildpack"
+title: "How to Build Go Apps with Paketo Buildpacks"
 weight: 304
 menu:
   main:
     parent: "howto"
+    name: "Go"
 aliases:
   - /docs/buildpacks/language-family-buildpacks/go
 ---
 
-The [Go Paketo Buildpack](https://github.com/paketo-buildpacks/go) supports several popular
-configurations for Go apps.
-
+## Build a Sample Go Application
 To build a sample app locally with this buildpack using the `pack` CLI, run
 
 {{< code/copyable >}}
@@ -26,15 +25,8 @@ for how to run the app.
 **NOTE: Though the example above uses the Paketo Base builder, this buildpack is
 also compatible with the Paketo Full builder and Paketo Tiny builder.**
 
-## Supported Dependencies
-
-The Go Paketo Buildpack supports several versions of Go.
-For more details on the specific versions supported in a given buildpack
-version, see the [release
-notes](https://github.com/paketo-buildpacks/go/releases).
-
-## Specifying a Go Version
-
+## Install a Specific Go Version
+ 
 The Go CNB (Cloud Native Buildpack) allows you to specify a version of Go to
 use during deployment. This version can be specified via the `BP_GO_VERSION`
 environment variable or `go.mod`. When specifying a version of Go, you must
@@ -70,7 +62,7 @@ Specifying the Go version through buildpack.yml configuration will be
 deprecated in Go Dist Buildpack v1.0.0. To migrate from using buildpack.yml
 please set the` $BP_GO_VERSION` environment variable.
 
-## Configuring Build Flags
+## Configure the `go build` Command
 
 The `go build` command supports a number of flags that allow users to override
 defaults for more control over build configurations. By default, the buildpack
@@ -110,8 +102,7 @@ Specifying the Go Build flags through buildpack.yml configuration will be
 deprecated in Go Build Buildpack v1.0.0. To migrate from using buildpack.yml
 please set the `$BP_GO_BUILD_FLAGS` environment variable.
 
-## Configuring Targets
-
+## Build Multiple Binaries In An App Image
 The Go CNB allows users to specify multiple targets for `go build`. This will
 result in multiples binaries being built.Targets must be a list of paths
 relative to the root directory of the source code.
@@ -128,7 +119,7 @@ Specifying the Go Build targets through buildpack.yml configuration will be
 deprecated in Go Build Buildpack v1.0.0. To migrate from using buildpack.yml
 please set the `$BP_GO_TARGETS` environment variable.
 
-## Configuring Import Paths
+## Configure Module Import Paths
 
 If you are building a $GOPATH application that imports its own sub-packages,
 you will need to specify the import paths for those sub-packages. The Go CNB
@@ -144,7 +135,7 @@ Specifying the Go Build import path through buildpack.yml configuration will be
 deprecated in Go Build Buildpack v1.0.0. To migrate from using buildpack.yml
 please set the `$BP_GO_BUILD_IMPORT_PATH` environment variable.
 
-## Configuring File Removal
+## Keep Specific Files in the App Image
 
 The Go CNB by defaults deletes the contents of your app root once it has
 compiled your app in an effort to optimize the size the final image. However
@@ -155,131 +146,25 @@ environment variable, which can be passed to `pack build`:
 BP_KEEP_FILES=assets/*:public/*
 {{< /code/copyable >}}
 
-## Package Management Options
-
-With the Go CNB, there are three options for package management depending on
-your application:
-* The built-in [Go modules](https://github.com/golang/go/wiki/Modules) feature,
-* The [Dep](https://github.com/golang/dep) tool
-* No package manager
-
-Support for each of these package managers is mutually-exclusive. You can find
-specific information for each option below.
-
-### Package Management with Go Modules
-
-Many Go apps require third-party libraries to perform common tasks and
-behaviors. Go modules are a built-in option for managing these third-party
-dependencies that the Go CNB fully supports. Including a `go.mod` file in your
-app source code instructs the buildpack to vendor your dependencies using Go
-modules. During the build phase, the `go-mod-vendor`
-[buildpack](https://github.com/paketo-buildpacks/go-mod-vendor) checks to see
-if the application requires any external modules and if it does, runs the `go
-mod vendor` command for your app. The resulting `vendor` directory will exist
-in the app's root directory and will contain all the packages needed to build
-your Go app.
-
-
-### Package Management with Dep
-
-Dep is an alternative option to Go Modules for package management in Go apps.
-Including a `Gopkg.toml` file (more information about this
-[here](https://golang.github.io/dep/docs/Gopkg.toml.html)) in your app source
-code instructs the buildpack to download the `dep` package, and then vendor
-your dependencies using it. There may be an optional `Gopkg.lock` file that
-outlines specific versions of the dependencies to be packaged. During its build
-phase, the `dep-ensure`
-[buildpack](https://github.com/paketo-buildpacks/dep-ensure) runs the `dep
-ensure` command for your app. The resulting `vendor` directory will exist in
-the app's root directory and will contain all the packages needed to build your
-Go app.
-
-### No Package Management
-
-The Go CNB also supports both self-vendored apps and simpler apps that do not
-require third-party packages. In this case there is no vendoring step, and the
-`go build` command is run on the app source code as it is provided.
-
-## Buildpack-Set Environment Variables
-
-The Go CNB sets a few environment variables during the `build` and `launch`
-phases of the app lifecycle. The sections below describe each environment
-variable and its impact on your app.
-
-### `GOPATH`
-
-The `GOPATH` environment variable tells Go where to look for artifacts such as
-source code and binaries. The Go CNB takes care of setting the `GOPATH` for
-you, depending on your app and which package management option your app uses.
-
-* Set by: `go-mod-vendor`, `dep-ensure` and `go-build`
-* Phases: `build`
-* Value: path to Go workspace
-
-#### Go Modules
-
-When using Go modules, the Go CNB sets the `GOPATH` to a cached module layer in
-the image so that between builds of the app, the dependencies don't have to be
-redownloaded. Essentially, the `GOPATH` is being used to tell the `go mod
-vendor` command where to look for dependencies. It's worth noting that in this
-case, the `GOPATH` isn't persisted beyond vendoring the dependencies and gets
-overwritten by a subsequent buildpack.
-
-#### Dep
-
-When using the Dep tool, the Go CNB sets the `GOPATH` to a temporary directory.
-The app source code gets copied into the `GOPATH` location so that the `dep
-ensure` command knows where to look for the source code, as well as where to
-put the `vendor` directory. The `vendor` directory that is created is then
-copied to the original source code directory. The `GOPATH` in this case is used
-to run `dep ensure`, but does not persist beyond that step.
-
-#### Build
-
-The `go-build` buildpack participates in the Go CNB in every case, regardless
-of which package management option is used. The `GOPATH` is set to a temporary
-directory which includes the app source code and local sub-packages. The
-`GOPATH` is utilized in running `go build` to compile your app.
-
-### `GOCACHE`
-
-The `GOCACHE` variable specifies where build outputs are stored for reuse in
-subsequent builds. It gets set to a cached layer in  the image by the
-`go-build` buildpack, so that it is persisted between builds.
-
-* Set by: `go-build`
-* Phases: `build`
-* Value: Go Cache layer path
-
-### `DEPCACHEDIR`
-
-`DEPCACHEDIR` specifies where upstream dependency source code is stored for use
-by the Dep tool. The `dep-ensure` buildpack sets this variable to the path of a
-cache layer in the app image.
-
-* Set by: `dep-ensure`
-* Phases: `build`
-* Value: Dep Cache layer path
-
-## Using CA Certificates
+## Install a Custom CA Certificate
 Go Buildpack users can provide their own CA certificates and have them
 included in the container root truststore at build-time and runtime by
 following the instructions outlined in the [CA
 Certificates](https://paketo.io/docs/buildpacks/configuration/#ca-certificates)
 section of our configuration docs.
 
-## Setting Custom Start Processes
+## Override the Start Process Set by the Buildpack
 Go Buildpack users can set custom start processes for their app image by
 following the instructions in the
 [Procfiles](https://paketo.io/docs/buildpacks/configuration/#procfiles) section
 of our configuration docs.
 
-## Setting Environment Variables in the App Image
+## Set Environment Variables for App Launch Time
 Go Buildpack users can embed launch-time environment variables in their
 app image by following the documentation for the [Environment Variables
 Buildpack](https://github.com/paketo-buildpacks/environment-variables/blob/main/README.md).
 
-## Adding Custom Labels to the App Image
+## Add Custom Labels to the App Image
 Go Buildpack users can add labels to their app image by following the
 instructions in the [Applying Custom
 Labels](https://paketo.io/docs/buildpacks/configuration/#applying-custom-labels)

--- a/content/docs/howto/httpd.md
+++ b/content/docs/howto/httpd.md
@@ -4,6 +4,7 @@ weight: 308
 menu:
   main:
     parent: "howto"
+    name: "HTTPD"
 aliases:
   - /docs/buildpacks/language-family-buildpacks/httpd/
 ---

--- a/content/docs/howto/java-native-image.md
+++ b/content/docs/howto/java-native-image.md
@@ -4,6 +4,7 @@ weight: 312
 menu:
   main:
     parent: "howto"
+    name: Java Native Image
 aliases:
   - /docs/buildpacks/language-family-buildpacks/java-native-image/
 ---

--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -4,6 +4,7 @@ weight: 316
 menu:
   main:
     parent: "howto"
+    name: "Java"
 aliases:
   - /docs/buildpacks/language-family-buildpacks/java/
 ---

--- a/content/docs/howto/nginx.md
+++ b/content/docs/howto/nginx.md
@@ -4,6 +4,7 @@ weight: 320
 menu:
   main:
     parent: "howto"
+    name: "NGINX"
 aliases:
   - /docs/buildpacks/language-family-buildpacks/nginx/
 ---

--- a/content/docs/howto/nodejs.md
+++ b/content/docs/howto/nodejs.md
@@ -4,6 +4,7 @@ weight: 324
 menu:
   main:
     parent: "howto"
+    name: "Node.js"
 aliases:
   - /docs/buildpacks/language-family-buildpacks/nodejs/
 ---

--- a/content/docs/howto/php.md
+++ b/content/docs/howto/php.md
@@ -4,6 +4,7 @@ weight: 328
 menu:
   main:
     parent: "howto"
+    name: "PHP"
 aliases:
   - /docs/buildpacks/language-family-buildpacks/php/
 ---

--- a/content/docs/howto/ruby.md
+++ b/content/docs/howto/ruby.md
@@ -4,6 +4,7 @@ weight: 332
 menu:
   main:
     parent: "howto"
+    name: "Ruby"
 aliases:
   - /docs/buildpacks/language-family-buildpacks/ruby/
 ---

--- a/content/docs/reference/go-reference.md
+++ b/content/docs/reference/go-reference.md
@@ -1,0 +1,125 @@
+---
+title: "Go Buildpack Reference"
+weight: 300
+menu:
+  main:
+    parent: Reference
+    identifier: go-reference
+    name: "Go Buildpack"
+---
+
+The [Go Paketo Buildpack](https://github.com/paketo-buildpacks/go) supports several popular
+configurations for Go apps.
+
+## Supported Dependencies
+
+The Go Paketo Buildpack supports several versions of Go.
+For more details on the specific versions supported in a given buildpack
+version, see the [release
+notes](https://github.com/paketo-buildpacks/go/releases).
+
+## Package Management Options
+
+With the Go CNB, there are three options for package management depending on
+your application:
+* The built-in [Go modules](https://github.com/golang/go/wiki/Modules) feature,
+* The [Dep](https://github.com/golang/dep) tool
+* No package manager
+
+Support for each of these package managers is mutually-exclusive. You can find
+specific information for each option below.
+
+### Package Management with Go Modules
+
+Many Go apps require third-party libraries to perform common tasks and
+behaviors. Go modules are a built-in option for managing these third-party
+dependencies that the Go CNB fully supports. Including a `go.mod` file in your
+app source code instructs the buildpack to vendor your dependencies using Go
+modules. During the build phase, the `go-mod-vendor`
+[buildpack](https://github.com/paketo-buildpacks/go-mod-vendor) checks to see
+if the application requires any external modules and if it does, runs the `go
+mod vendor` command for your app. The resulting `vendor` directory will exist
+in the app's root directory and will contain all the packages needed to build
+your Go app.
+
+
+### Package Management with Dep
+
+Dep is an alternative option to Go Modules for package management in Go apps.
+Including a `Gopkg.toml` file (more information about this
+[here](https://golang.github.io/dep/docs/Gopkg.toml.html)) in your app source
+code instructs the buildpack to download the `dep` package, and then vendor
+your dependencies using it. There may be an optional `Gopkg.lock` file that
+outlines specific versions of the dependencies to be packaged. During its build
+phase, the `dep-ensure`
+[buildpack](https://github.com/paketo-buildpacks/dep-ensure) runs the `dep
+ensure` command for your app. The resulting `vendor` directory will exist in
+the app's root directory and will contain all the packages needed to build your
+Go app.
+
+### No Package Management
+
+The Go CNB also supports both self-vendored apps and simpler apps that do not
+require third-party packages. In this case there is no vendoring step, and the
+`go build` command is run on the app source code as it is provided.
+
+## Buildpack-Set Environment Variables
+
+The Go CNB sets a few environment variables during the `build` and `launch`
+phases of the app lifecycle. The sections below describe each environment
+variable and its impact on your app.
+
+### `GOPATH`
+
+The `GOPATH` environment variable tells Go where to look for artifacts such as
+source code and binaries. The Go CNB takes care of setting the `GOPATH` for
+you, depending on your app and which package management option your app uses.
+
+* Set by: `go-mod-vendor`, `dep-ensure` and `go-build`
+* Phases: `build`
+* Value: path to Go workspace
+
+#### Go Modules
+
+When using Go modules, the Go CNB sets the `GOPATH` to a cached module layer in
+the image so that between builds of the app, the dependencies don't have to be
+redownloaded. Essentially, the `GOPATH` is being used to tell the `go mod
+vendor` command where to look for dependencies. It's worth noting that in this
+case, the `GOPATH` isn't persisted beyond vendoring the dependencies and gets
+overwritten by a subsequent buildpack.
+
+#### Dep
+
+When using the Dep tool, the Go CNB sets the `GOPATH` to a temporary directory.
+The app source code gets copied into the `GOPATH` location so that the `dep
+ensure` command knows where to look for the source code, as well as where to
+put the `vendor` directory. The `vendor` directory that is created is then
+copied to the original source code directory. The `GOPATH` in this case is used
+to run `dep ensure`, but does not persist beyond that step.
+
+#### Build
+
+The `go-build` buildpack participates in the Go CNB in every case, regardless
+of which package management option is used. The `GOPATH` is set to a temporary
+directory which includes the app source code and local sub-packages. The
+`GOPATH` is utilized in running `go build` to compile your app.
+
+### `GOCACHE`
+
+The `GOCACHE` variable specifies where build outputs are stored for reuse in
+subsequent builds. It gets set to a cached layer in  the image by the
+`go-build` buildpack, so that it is persisted between builds.
+
+* Set by: `go-build`
+* Phases: `build`
+* Value: Go Cache layer path
+
+### `DEPCACHEDIR`
+
+`DEPCACHEDIR` specifies where upstream dependency source code is stored for use
+by the Dep tool. The `dep-ensure` buildpack sets this variable to the path of a
+cache layer in the app image.
+
+* Set by: `dep-ensure`
+* Phases: `build`
+* Value: Dep Cache layer path


### PR DESCRIPTION
Part of #203 

- Small tweaks to many of the existing markdown files so their menu titles match the Figma
- Splits the existing Go docs content into How To and Reference sections. No new content has been added.
     - h2s in the How To section have been changed so they all make sense in a sentence like "How to ________"