### PR TITLE
move TOC to right side of docs on wider screens

### DIFF
--- a/assets/css/v2/docs.scss
+++ b/assets/css/v2/docs.scss
@@ -126,6 +126,9 @@ body {
 
     @media (min-width: $header-hamburger-breakpoint) {
         width: calc(100% - 380px);
+        display: flex;
+        flex-direction: row;
+        padding-right: 30px;
     }
 
     @media (min-width: $mobile-breakpoint) {
@@ -209,6 +212,32 @@ body {
 .docs-body__table-of-contents ul li ul { // indent h3 subheaders
        padding: 0 1em;
    }
+
+.docs-body__table-of-contents-container {
+    display: none;
+
+    padding-top: 40px;
+    padding-left: 48px;
+    max-width: 600px;
+}
+
+.docs-body__table-of-contents--desktop {
+    display: none;
+}
+
+@media(min-width: $table-of-contents-breakpoint) {
+    .docs-body__table-of-contents--mobile {
+        display: none;
+    }
+
+    .docs-body__table-of-contents--desktop {
+        display: block;
+    }
+
+    .docs-body__table-of-contents-container {
+        display: block;
+    }
+}
 
 /* github redirect */
 

--- a/assets/css/v2/variables.scss
+++ b/assets/css/v2/variables.scss
@@ -2,6 +2,7 @@
 $mobile-breakpoint : 480px;
 $mobile-breakpoint-footer: 800px;
 $header-hamburger-breakpoint: 800px;
+$table-of-contents-breakpoint: 1200px;
 
 /* color variables */
 $light-text-color : #ffffff;

--- a/layouts/partials/docs-body.html
+++ b/layouts/partials/docs-body.html
@@ -4,16 +4,19 @@
     </div>
     <div class="docs-body">
         <div class="docs-body__container">
+            {{ partial "github-edit.html" . }}
             <h1 class="">{{ .Title }}</h1>
-            {{ partial "v2/docs-table-of-contents.html" . }}
+            {{ partial "v2/docs-table-of-contents.html" (dict "context" . "viewer" "mobile") }}
             {{ .Scratch.Set "path" .File.Path }}
             {{ .Scratch.Set "filename" .File.TranslationBaseName }}
-            {{ partial "github-edit.html" . }}
             <div class="docs-body__markdown">
                 {{ .Content }}
             </div>
             {{ partial "github-edit.html" . }}
+            <p class="docs-mod-time"><strong>Last modified:</strong> {{ .Lastmod.Format "January 2, 2006" }}</p>
         </div>
-        <p class="docs-mod-time"><strong>Last modified:</strong> {{ .Lastmod.Format "January 2, 2006" }}</p>
+        <div class="docs-body__table-of-contents-container">
+            {{ partial "v2/docs-table-of-contents.html" (dict "context" . "viewer" "desktop") }}
+        </div>
     </div>
 </div>

--- a/layouts/partials/v2/docs-table-of-contents.html
+++ b/layouts/partials/v2/docs-table-of-contents.html
@@ -1,3 +1,3 @@
-<div class="docs-body__table-of-contents">
-    {{ .Page.TableOfContents }}
+<div class="docs-body__table-of-contents docs-body__table-of-contents--{{ .viewer }}">
+    {{ .context.Page.TableOfContents }}
 </div>


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
![image](https://user-images.githubusercontent.com/21328286/124788386-48968d00-df17-11eb-82e5-309dd1ee7150.png)
The Figma mockup shows the Table of Contents for pages in desktop/wider screen view to the right of main page content. Since the page content starts to be squished by the righthand TOC for screens significantly larger than the mobile view, I set up a new media query breakpoint specifically for this feature. Happy to discuss a different responsive approach if this one feels off.



## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
