### PR TITLE
make section header menu items un-click-able

### DIFF
--- a/assets/css/v2/docs.scss
+++ b/assets/css/v2/docs.scss
@@ -64,6 +64,18 @@ body {
     padding: 0;
     padding-right: 5px;
 }
+.docs-menu__section-header {
+    cursor: default;
+    display: inline-block;
+    position: relative;
+    margin: 5px 0;
+    padding: 5px;
+    padding-left: 10px;
+    padding-right: 10px;
+    text-decoration: none;
+    opacity: 1;
+    color: $light-text-color;
+}
 
 .docs-menu__link {
     display: inline-block;

--- a/config.toml
+++ b/config.toml
@@ -119,15 +119,24 @@ lastmod = ["lastmod", ":fileModTime", ":default"]
     name = "Reference"
     weight = 500
 
+    [menu.main.params]
+      class = "docs-menu__section-header"
+
   [[menu.main]]
     identifier = "howto"
     name = "How To"
     weight = 200
 
+    [menu.main.params]
+      class = "docs-menu__section-header"
+
   [[menu.main]]
     identifier = "concepts"
     name = "Concepts"
     weight = 300
+
+    [menu.main.params]
+      class = "docs-menu__section-header"
 
 
 [markup]

--- a/layouts/partials/docs-sidebar.html
+++ b/layouts/partials/docs-sidebar.html
@@ -15,10 +15,17 @@
     {{- $entry := .entry }}
     {{ if $entry.HasChildren }}
         <li class="docs-menu__parent">
+            {{ if isset $entry.Params "class" }}
+            <div class="{{ $entry.Params.class }}">
+                {{ $entry.Pre }}
+                <span>{{ $entry.Name }}</span>
+            </div>
+            {{ else }}
             <a href="{{ $entry.URL }}"  class="docs-menu__link {{ if $currentPage.IsMenuCurrent "main" $entry }}docs-menu__link--active{{ end }}">
                 {{ $entry.Pre }}
                 <span>{{ $entry.Name }}</span>
             </a>
+            {{ end }}
             <ul class="docs-menu__children-list">
                 {{ range $entry.Children }}
                     {{ template "docs-menu-entry"  dict "currentPage" $currentPage "entry" . }}


### PR DESCRIPTION

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Resolves #212 

## Use Cases
<!-- An explanation of the use cases your change enables -->

Now, you should be able to mouse over the "Concepts" "Reference" and "How To" headers *without* them activating as links.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
