### PR TITLE
correct go reference docs menu frontmatter

### DIFF
--- a/content/docs/reference/go-reference.md
+++ b/content/docs/reference/go-reference.md
@@ -3,7 +3,7 @@ title: "Go Buildpack Reference"
 weight: 300
 menu:
   main:
-    parent: Reference
+    parent: reference
     identifier: go-reference
     name: "Go Buildpack"
 ---


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Currently, on the Paketo site, there are 2 Reference sections. This is caused by a typo in the frontmatter on the Go Reference docs page.
![image](https://user-images.githubusercontent.com/21328286/124821146-590d2e80-df3c-11eb-9e92-8dfdf87a1a97.png)


This fix eliminates the double header.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
