### PR TITLE
reorganize ruby docs

### DIFF
--- a/content/docs/reference/ruby-reference.md
+++ b/content/docs/reference/ruby-reference.md
@@ -1,0 +1,72 @@
+---
+title: "Ruby Buildpack Reference"
+menu:
+  main:
+    parent: reference
+    identifier: ruby-reference
+    name: "Ruby Buildpack"
+---
+
+This reference documentation offers an in-depth description of the behavior
+and configuration options of the 
+[Paketo Ruby Buildpack](https://github.com/paketo-buildpacks/ruby).
+For explanations of how to use the buildpack for several common use-cases, see
+the Ruby How To [documentation](/docs/howto/ruby).
+
+## Supported Dependencies
+
+The Ruby Paketo Buildpack supports several versions of
+[MRI](https://www.ruby-lang.org), [Bundler](https://bundler.io/), and common
+Ruby webservers and task runners.  For more details on the specific versions
+supported in a given buildpack version, see the [release
+notes](https://github.com/paketo-buildpacks/ruby/releases/latest).
+
+## Package Management
+
+The Ruby Buildpack uses [Bundler](https://bundler.io/) to install and manage
+the gems needed to run your application. Including a `Gemfile` in your app
+source code instructs the [`bundle-install`
+buildpack](https://github.com/paketo-buildpacks/bundle-install) to vendor your
+dependencies using `bundle install`.
+
+## Webservers & Task Runners
+
+The Ruby Buildpack supports a number of webservers and task runners that are
+useful for running Ruby applications. If your application uses one of these
+tools, it will be automatically detected and a start command for your
+application will be assigned when building your application container.
+
+### Webservers
+
+* [Passenger](http://github.com/paketo-buildpacks/passenger)
+* [Puma](http://github.com/paketo-buildpacks/puma)
+* [Rackup](http://github.com/paketo-buildpacks/rackup)
+* [Thin](http://github.com/paketo-buildpacks/thin)
+* [Unicorn](http://github.com/paketo-buildpacks/unicorn)
+
+### Task Runners
+
+* [Rake](http://github.com/paketo-buildpacks/rake)
+
+## Rails Asset Pipeline
+The [Paketo Rails Assets Buildpack](http://github.com/paketo-buildpacks/rails-assets) is a [component buildpack](/docs/concepts/buildpacks/#component-buildpacks) included in the Ruby Buildpack. It supports Rails apps (Rails version >= 5.0) that need asset precompilation.
+
+The buildpack runs bundle exec rails assets:precompile for the app, and works with any of the supported Ruby webservers listed above.
+
+## Buildpack-Set Environment Variables
+
+The Ruby CNB sets a few environment variables during the `build` and `launch`
+phases of the app lifecycle. The sections below describe each environment
+variable and its impact on your app.
+
+### `GEM_PATH`
+
+* Set by: `mri`, `bundler`
+* Phases: `build` and `launch`
+* Value: location of the directory gems will be installed for each respective dependency
+
+### `BUNDLE_PATH`
+
+* Set by: `bundle-install`
+* Phases: `build` and `launch`
+* Value: location where all gems in your bundle will be located


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Part of #203 
- Splits the existing ruby docs content into How To and Reference sections.
     - h2s in the How To section have been changed so they all make sense in a sentence like "How to ________"
     - **Some net-new content was added in the How To section to try and capture some info about rake tasks and web servers** @paketo-buildpacks/ruby-maintainers please fact check the new stuff.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
