### PR TITLE
give TOC a min-width

### DIFF
--- a/assets/css/v2/docs.scss
+++ b/assets/css/v2/docs.scss
@@ -209,45 +209,40 @@ body {
 }
 
 /* table of contents */
-.docs-body__table-of-contents {
+.docs-body__table-of-contents-container {
     color: $dark-text-color;
     font-size: 17px;
     line-height: 24px;
     text-decoration-line: underline;
 }
 
-.docs-body__table-of-contents ul {
+.docs-body__table-of-contents-container ul {
     list-style: none;
     padding: 0px;               // don't indent h2 headers
 }
 
-.docs-body__table-of-contents ul li ul { // indent h3 subheaders
+.docs-body__table-of-contents-container ul li ul { // indent h3 subheaders
        padding: 0 1em;
    }
 
-.docs-body__table-of-contents-container {
-    display: none;
-
-    padding-top: 40px;
-    padding-left: 48px;
-    max-width: 600px;
-    min-width: 350px;
-}
-
-.docs-body__table-of-contents--desktop {
-    display: none;
+.docs-body__table-of-contents-container--desktop {
+    display: none
 }
 
 @media(min-width: $table-of-contents-breakpoint) {
-    .docs-body__table-of-contents--mobile {
+
+    .docs-body__table-of-contents-container {
+        padding-top: 40px;
+        padding-left: 48px;
+        max-width: 600px;
+        min-width: 350px;
+    }
+
+    .docs-body__table-of-contents-container--mobile {
         display: none;
     }
 
-    .docs-body__table-of-contents--desktop {
-        display: block;
-    }
-
-    .docs-body__table-of-contents-container {
+    .docs-body__table-of-contents-container--desktop {
         display: block;
     }
 }

--- a/assets/css/v2/docs.scss
+++ b/assets/css/v2/docs.scss
@@ -231,6 +231,7 @@ body {
     padding-top: 40px;
     padding-left: 48px;
     max-width: 600px;
+    min-width: 350px;
 }
 
 .docs-body__table-of-contents--desktop {

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -5,6 +5,7 @@ menu: "main"
 aliases:
   - /docs/
   - /docs/buildpacks/language-family-buildpacks/
+toc: false
 ---
 
 This section gets you started with Paketo Buildpacks using Paketo **Builders**, the **Pack** CLI, and **Docker**.

--- a/layouts/partials/docs-body.html
+++ b/layouts/partials/docs-body.html
@@ -15,8 +15,6 @@
             {{ partial "github-edit.html" . }}
             <p class="docs-mod-time"><strong>Last modified:</strong> {{ .Lastmod.Format "January 2, 2006" }}</p>
         </div>
-        <div class="docs-body__table-of-contents-container">
-            {{ partial "v2/docs-table-of-contents.html" (dict "context" . "viewer" "desktop") }}
-        </div>
+        {{ partial "v2/docs-table-of-contents.html" (dict "context" . "viewer" "desktop") }}
     </div>
 </div>

--- a/layouts/partials/v2/docs-table-of-contents.html
+++ b/layouts/partials/v2/docs-table-of-contents.html
@@ -1,3 +1,5 @@
-<div class="docs-body__table-of-contents docs-body__table-of-contents--{{ .viewer }}">
-    {{ .context.Page.TableOfContents }}
+{{ if ne .context.Params.toc false}}
+<div class="docs-body__table-of-contents-container docs-body__table-of-contents-container--{{ .viewer }}">
+    {{ .context.Page.TableOfContents  }}
 </div>
+{{ end }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
In the desktop-view mode for the table of contents, as a user shrinks the screen width, the table of contents becomes quite narrow:
![image](https://user-images.githubusercontent.com/21328286/125122244-23468200-e0c3-11eb-9df2-aafe46732757.png)


This change adds a min width to the TOC that keeps things looking more like:

![image](https://user-images.githubusercontent.com/21328286/125122197-0ca02b00-e0c3-11eb-8039-2338bf4b76b4.png)


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
