### PR TITLE
Shortcodes for How To and Reference Executive Summaries

### DIFF
--- a/content/docs/howto/dotnet-core.md
+++ b/content/docs/howto/dotnet-core.md
@@ -9,10 +9,7 @@ aliases:
   - /docs/buildpacks/language-family-buildpacks/dotnet-core/
 ---
 
-This documentation explains how to use the [Paketo .NET Core Buildpack](https://github.com/paketo-buildpacks/dotnet-core)
-to build applications for several common .NET use-cases. For more in-depth
-description of the buildpack's behavior and configuration see the .NET Core
-Buildpack Reference [documentation](/docs/reference/dotnet-core-reference).
+{{% howto_exec_summary bp_name="Paketo .NET Core Buildpack" bp_repo="https://github.com/paketo-buildpacks/dotnet-core" reference_docs_path="/docs/reference/dotnet-core-reference" %}}
 
 ## Build a Sample App
 To build your app locally with the buildpack using the `pack` CLI, run

--- a/content/docs/howto/go.md
+++ b/content/docs/howto/go.md
@@ -9,6 +9,9 @@ aliases:
   - /docs/buildpacks/language-family-buildpacks/go
 ---
 
+{{% howto_exec_summary bp_name="Paketo Go Buildpack" bp_repo="https://github.com/paketo-buildpacks/go" reference_docs_path="/docs/reference/go-reference" %}}
+
+
 ## Build a Sample Go Application
 To build a sample app locally with this buildpack using the `pack` CLI, run
 

--- a/content/docs/howto/ruby.md
+++ b/content/docs/howto/ruby.md
@@ -9,11 +9,7 @@ aliases:
   - /docs/buildpacks/language-family-buildpacks/ruby/
 ---
 
-This documentation explains how to use the
-[Paketo Ruby Buildpack](https://github.com/paketo-buildpacks/ruby)
-to build applications for several common Ruby use-cases. For more in-depth
-description of the buildpack's behavior and configuration, see the Ruby
-Buildpack Reference [documentation](/docs/reference/ruby-reference).
+{{% howto_exec_summary bp_name="Paketo Ruby Buildpack" bp_repo="https://github.com/paketo-buildpacks/ruby" reference_docs_path="/docs/reference/ruby-reference" %}}
 
 ## Build a Sample App
 To build a sample app locally with this buildpack using the `pack` CLI, run

--- a/content/docs/howto/web-servers.md
+++ b/content/docs/howto/web-servers.md
@@ -18,11 +18,7 @@ for each web server buildpack.
 
 ## HTTPD
 
-The [Paketo HTTPD Buildpack](https://github.com/paketo-buildpacks/httpd) enables
-users to build apps that run an Apache HTTPD server. The following are explanations
-of common HTTPD Buildpack user workflows. For more in-depth
-description of the buildpack's behavior and configuration, see the HTTPD Buildpack
-reference [documentation](/docs/reference/httpd-reference).
+{{% howto_exec_summary bp_name="Paketo HTTPD Buildpack" bp_repo="https://github.com/paketo-buildpacks/httpd" reference_docs_path="/docs/reference/httpd-reference" %}}
 
 ### Build a Sample App
 To build a sample app locally with this CNB using the `pack` CLI, run
@@ -78,11 +74,7 @@ launches.
 
 ## NGINX
 
-The [Paketo NGINX Buildpack](https://github.com/paketo-buildpacks/nginx) enables
-users to build apps that run an NGINX server. The following are explanations
-of common NGINX Buildpack user workflows. For more in-depth
-description of the buildpack's behavior and configuration see the NGINX Buildpack
-reference [documentation](/docs/reference/nginx-reference).
+{{% howto_exec_summary bp_name="Paketo NGINX Buildpack" bp_repo="https://github.com/paketo-buildpacks/nginx" reference_docs_path="/docs/reference/nginx-reference" %}}
 
 ### Build a Sample App
 To build a sample app locally with this CNB using the `pack` CLI, run

--- a/content/docs/reference/dotnet-core-reference.md
+++ b/content/docs/reference/dotnet-core-reference.md
@@ -7,11 +7,7 @@ menu:
     name: ".NET Core Buildpack"
 ---
 
-This reference documentation offers an in-depth description of the behavior
-and configuration options of the 
-[Paketo .NET Core Buildpack](https://github.com/paketo-buildpacks/dotnet-core).
-For explanations of how to use the buildpack for several common use-cases, see
-the .NET Core How To [documentation](/docs/howto/dotnet-core). 
+{{% reference_exec_summary bp_name="Paketo .NET Core Buildpack" bp_repo="https://github.com/paketo-buildpacks/dotnet-core" howto_docs_path="/docs/howto/dotnet-core" %}}
 
 ## Supported Dependencies
 

--- a/content/docs/reference/go-reference.md
+++ b/content/docs/reference/go-reference.md
@@ -8,9 +8,7 @@ menu:
     name: "Go Buildpack"
 ---
 
-The [Go Paketo Buildpack](https://github.com/paketo-buildpacks/go) supports several popular
-configurations for Go apps.
-
+{{% reference_exec_summary bp_name="Paketo Go Buildpack" bp_repo="https://github.com/paketo-buildpacks/go" howto_docs_path="/docs/howto/go" %}}
 ## Supported Dependencies
 
 The Go Paketo Buildpack supports several versions of Go.

--- a/content/docs/reference/httpd-reference.md
+++ b/content/docs/reference/httpd-reference.md
@@ -8,11 +8,7 @@ menu:
     name: "HTTPD Buildpack"
 ---
 
-This reference documentation offers an in-depth description of the behavior
-and configuration options of the 
-[Paketo HTTPD Buildpack](https://github.com/paketo-buildpacks/httpd).
-For explanations of how to use the buildpack for several common use-cases, see
-the Web Servers How To [documentation](/docs/howto/web-servers/#httpd). 
+{{% reference_exec_summary bp_name="Paketo HTTPD Buildpack" bp_repo="https://github.com/paketo-buildpacks/httpd" howto_docs_path="/docs/howto/web-servers/#httpd" %}}
 
 The HTTPD Paketo Buildpack supports the installation of the
 Apache HTTP Server binary distribution

--- a/content/docs/reference/nginx-reference.md
+++ b/content/docs/reference/nginx-reference.md
@@ -7,11 +7,7 @@ menu:
     name: "NGINX Buildpack"
 ---
 
-This reference documentation offers an in-depth description of the behavior
-and configuration options of the 
-[Paketo NGINX Buildpack](https://github.com/paketo-buildpacks/nginx).
-For explanations of how to use the buildpack for several common use-cases, see
-the Web Servers How To [documentation](/docs/howto/web-servers/#nginx). 
+{{% reference_exec_summary bp_name="Paketo NGINX Buildpack" bp_repo="https://github.com/paketo-buildpacks/nginx" howto_docs_path="/docs/howto/web-servers/#nginx" %}}
 
 The NGINX Paketo Buildpack supports the installation of the NGINX binary distribution onto
 the `$PATH` inside a container. This makes it available to subsequent

--- a/content/docs/reference/ruby-reference.md
+++ b/content/docs/reference/ruby-reference.md
@@ -7,11 +7,7 @@ menu:
     name: "Ruby Buildpack"
 ---
 
-This reference documentation offers an in-depth description of the behavior
-and configuration options of the 
-[Paketo Ruby Buildpack](https://github.com/paketo-buildpacks/ruby).
-For explanations of how to use the buildpack for several common use-cases, see
-the Ruby How To [documentation](/docs/howto/ruby).
+{{% reference_exec_summary bp_name="Paketo Ruby Buildpack" bp_repo="https://github.com/paketo-buildpacks/ruby" howto_docs_path="/docs/howto/ruby" %}}
 
 ## Supported Dependencies
 

--- a/layouts/shortcodes/howto_exec_summary.md
+++ b/layouts/shortcodes/howto_exec_summary.md
@@ -1,0 +1,5 @@
+This documentation explains how to use the {{ with .Get "bp_name" }}
+[{{ . }}{{ end }}]({{ with .Get "bp_repo" }}{{ . }}{{ end }})
+to build applications for several common use-cases. For more in-depth
+description of the buildpack's behavior and configuration see the {{ with .Get "bp_name" }} {{ . }} {{ end }}
+Reference [documentation]({{ with .Get "reference_docs_path" }} {{ . }} {{ end }}).

--- a/layouts/shortcodes/reference_exec_summary.md
+++ b/layouts/shortcodes/reference_exec_summary.md
@@ -1,0 +1,4 @@
+This reference documentation offers an in-depth description of the behavior
+and configuration options of the {{ with .Get "bp_name" }}
+[{{ . }}{{ end }}]({{ with .Get "bp_repo" }}{{ . }}{{ end }}). For explanations of how to use the buildpack for several common use-cases, see
+the {{ with .Get "bp_name" }} {{ . }} {{ end }} How To [documentation]({{ with .Get "howto_docs_path" }} {{ . }} {{ end }}).


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
I created two shortcodes for the executive summaries (paragraphs explaining what the rest of the page is for) of the How To and Reference docs. I thought this would be a good use of a parameterized shortcode because it'll improve our docs' readability if each page has some common elements. Rather than put the onus on docs writers to keep the prose of this executive summary clear and aligned with the rest of the project, we can extract the prose, wordsmith it as a standalone entity, and substitute in the particulars of each buildpack as needed.

This is a first foray into using shortcodes to produce better docs consistency for users with less maintenance burden and prose-writing needed from buildpacks maintainers.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
