### PR TITLE
Fix bug where dev PR site not deployed

### DIFF
--- a/.github/workflows/deploy-dev-pr.yml
+++ b/.github/workflows/deploy-dev-pr.yml
@@ -3,7 +3,8 @@ name: Deploy PR to Firebase
 on:
   pull_request:
     types:
-    - synchronize # new commits pushed, hopefully this covers 'opened' too.
+    - opened
+    - synchronize
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
- We were only deploying a dev site for a PR when it
  was updated but not the first time a PR was opened

fixes gh-199

* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
