### PR TITLE
fix edit on github button

### DIFF
--- a/layouts/partials/docs-body.html
+++ b/layouts/partials/docs-body.html
@@ -7,8 +7,6 @@
             {{ partial "github-edit.html" . }}
             <h1 class="">{{ .Title }}</h1>
             {{ partial "v2/docs-table-of-contents.html" (dict "context" . "viewer" "mobile") }}
-            {{ .Scratch.Set "path" .File.Path }}
-            {{ .Scratch.Set "filename" .File.TranslationBaseName }}
             <div class="docs-body__markdown">
                 {{ .Content }}
             </div>

--- a/layouts/partials/github-edit.html
+++ b/layouts/partials/github-edit.html
@@ -1,12 +1,12 @@
-{{ $path := .Scratch.Get "path" }}
-{{ $filename := .Scratch.Get "filename" }}
+{{ $path := .File.Path }}
+{{ $filename := .File.TranslationBaseName }}
 {{/* Add language families to this slice as we migrate docs to modules */}}
-{{ $langFams := slice "dotnet-core"}}
-{{ .Scratch.Set "url" (printf "http://github.com/paketo-buildpacks/paketo-website/edit/main/content/%s" $path) }}
+{{ $langFams := slice "" }}
+{{ $url := (printf "http://github.com/paketo-buildpacks/paketo-website/edit/main/content/%s" $path) }}
 {{if (in $langFams $filename) }}
-  {{ .Scratch.Set "url" (printf "http://github.com/paketo-buildpacks/%s/edit/main/docs/content/%s.md" $filename $filename) }}
+  {{ $url = (printf "http://github.com/paketo-buildpacks/%s/edit/main/docs/content/%s.md" $filename $filename) }}
 {{ end }}
-  <a href="{{ .Scratch.Get "url" }}" target="_blank" class="github-edit" style="text-decoration:none">
+  <a href="{{ $url }}" target="_blank" class="github-edit" style="text-decoration:none">
     <div class="github-edit__content">
       <div class="github-edit__logo-container">
         <img class="github-edit__logo" src="/images/github-mark.png">


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Currently, on the Paketo site, there's an Edit on Github button at the top and bottom of each docs page. Only the bottom one on each page works.
(Try the buttons on https://paketo.io/docs/concepts/buildpacks/ for instance)

This is because the edit on github partial was relying on receiving certain manually-set variables from its caller. Instead, the partial has been refactored to pull the information it needs from the provided page context.
## Use Cases
<!-- An explanation of the use cases your change enables -->
Now the partial can be safely used on any Markdown page without the caller needing to set up additional scratch variables. And site users don't run into a broken link at the top of each docs page.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
