### PR TITLE
annotate external links

### DIFF
--- a/assets/css/v2/text.scss
+++ b/assets/css/v2/text.scss
@@ -33,7 +33,7 @@
     margin-bottom: 40px;
 }
 
-.text__screen-reader-link {
+.screen-reader-link-text {
     position: absolute;
     width: 1px;
     clip: rect(0 0 0 0);

--- a/assets/css/v2/text.scss
+++ b/assets/css/v2/text.scss
@@ -33,6 +33,14 @@
     margin-bottom: 40px;
 }
 
+.text__screen-reader-link {
+    position: absolute;
+    width: 1px;
+    clip: rect(0 0 0 0);
+    overflow: hidden;
+    white-space: nowrap;
+}
+
 .text--light {
     color: $light-text-color;
 }

--- a/assets/js/components/links.js
+++ b/assets/js/components/links.js
@@ -1,6 +1,11 @@
 export default function OpenExternalLinksInNewTab({ links, hostname }) {
   for (const link of links) {
     if (link.hostname != hostname) {
+      var alertElement = document.createElement('span');
+      alertElement.appendChild(document.createTextNode("(opens in a new tab)"));
+      alertElement.classList.add("text__screen-reader-link");
+      link.appendChild(alertElement)
+
       link.target = '_blank';
     }
   }

--- a/assets/js/components/links.js
+++ b/assets/js/components/links.js
@@ -3,7 +3,7 @@ export default function OpenExternalLinksInNewTab({ links, hostname }) {
     if (link.hostname != hostname) {
       var alertElement = document.createElement('span');
       alertElement.appendChild(document.createTextNode("(opens in a new tab)"));
-      alertElement.classList.add("text__screen-reader-link");
+      alertElement.classList.add("screen-reader-link-text");
       link.appendChild(alertElement)
 
       link.target = '_blank';


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This change resolves #196, adding a hidden span tag that alerts screen-readers of any external links that open in a new tab, as detailed [here](https://codersblock.com/blog/external-links-new-tabs-and-accessibility/#how-to-inform-your-users). This change affects all external links.
## Use Cases
<!-- An explanation of the use cases your change enables -->
This change allows those who use websites without vision to get a clear understanding of which urls link to external sites.
## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
