### PR TITLE
Fixing buildpack links

### DIFF
--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -418,8 +418,8 @@ The following component buildpacks compose the Java Buildpack. Buildpacks are li
 [bp/azul-zulu]:https://github.com/paketo-buildpacks/azul-zulu
 [bp/eclipse-openj9]:https://github.com/paketo-buildpacks/eclipse-openj9
 [bp/graalvm]:https://github.com/paketo-buildpacks/graalvm
-[bp/dragonwell]:https://github.com/paketo-buildpacks/graalvm
-[bp/microsoft]:https://github.com/paketo-buildpacks/graalvm
+[bp/dragonwell]:https://github.com/paketo-buildpacks/alibaba-dragonwell
+[bp/microsoft]:https://github.com/paketo-buildpacks/microsoft-openjdk
 [bp/sap-machine]:https://github.com/paketo-buildpacks/sap-machine
 [bp/ca-certificates]:https://github.com/paketo-buildpacks/ca-certificates
 [bp/debug]:https://github.com/paketo-buildpacks/debug


### PR DESCRIPTION
Fixing links to dragonwell and microsoft openjdk

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ x] I have added an integration test, if necessary.
* [ x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
