### PR TITLE
Automatically comment on PR with staging link

### DIFF
--- a/.github/workflows/deploy-dev-pr.yml
+++ b/.github/workflows/deploy-dev-pr.yml
@@ -43,8 +43,15 @@ jobs:
       run: hugo
 
     - name: Deploy
+      id: deploy
       uses: actions/github-script@v4
       with:
         script: |
             const deploy = require('./deploy.js')
             await deploy({ expires: '72h' })
+    - name: Comment with Staging Link
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        message: |
+          PR deployed to: ${{ steps.deploy.outputs.staging_url }}
+          Expires at: ${{ steps.deploy.outputs.expiration }}

--- a/deploy.js
+++ b/deploy.js
@@ -14,6 +14,8 @@ module.exports = async ({ expires } = { expires: '1h'}) => {
     .then((data) => {
       console.log(`PR DEPLOYED TO: ${data['paketo-stage'].url}`)
       console.log(`SITE EXPIRES AT: ${data['paketo-stage'].expireTime} (in ${expires})`)
+      console.log(`::set-output name=staging_url::${data['paketo-stage'].url}`)
+      console.log(`::set-output name=expiration::${data['paketo-stage'].expireTime} (in ${expires})`)
     })
     .catch((err) => {
       console.log(`deploy: ${err}`);


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Each time the deploy workflow runs on a PR, it will create or update the comment on the PR.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Reviewers can easily find the staging site link for a PR without looking at the status check output.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
