### PR TITLE
simplify github edit partial

### DIFF
--- a/layouts/partials/github-edit.html
+++ b/layouts/partials/github-edit.html
@@ -1,11 +1,4 @@
-{{ $path := .File.Path }}
-{{ $filename := .File.TranslationBaseName }}
-{{/* Add language families to this slice as we migrate docs to modules */}}
-{{ $langFams := slice "" }}
-{{ $url := (printf "http://github.com/paketo-buildpacks/paketo-website/edit/main/content/%s" $path) }}
-{{if (in $langFams $filename) }}
-  {{ $url = (printf "http://github.com/paketo-buildpacks/%s/edit/main/docs/content/%s.md" $filename $filename) }}
-{{ end }}
+{{ $url := (printf "http://github.com/paketo-buildpacks/paketo-website/edit/main/content/%s" .File.Path ) }}
   <a href="{{ $url }}" target="_blank" class="github-edit" style="text-decoration:none">
     <div class="github-edit__content">
       <div class="github-edit__logo-container">


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Remove special-casing for docs that are checked into
language family repos (because we are moving away from Hugo modules)

Now that docs have been [split into reference and how to](https://github.com/paketo-buildpacks/paketo-website/blob/83949c10c038d37abb52f4394b8d805dcdbe209f/content/docs), it's not obvious what we gain from pushing language family documentation into their own repos. Ideally, how to documentation will change infrequently and reference documentation will be automatically generated on each buildpack release.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
