### PR TITLE
use only built artifacts from manual PR deploys

### DIFF
--- a/.github/workflows/deploy-dev-pr.yml
+++ b/.github/workflows/deploy-dev-pr.yml
@@ -55,6 +55,10 @@ jobs:
     - name: Build
       run: hugo
 
+    - name: Switch Back to Original Branch  # Built contents in /public is unaffected
+      if: github.event_name == 'workflow_dispatch'
+      run: git checkout -
+
     - name: Deploy
       id: deploy
       uses: actions/github-script@v4

--- a/deploy.js
+++ b/deploy.js
@@ -5,16 +5,11 @@ module.exports = async ({ expires } = { expires: '1h'}) => {
 
   var channelID = "pr";
 
-  console.log(`channelID: ${channelID}`);
-  console.log(`GH_HEAD_REF: ${GITHUB_HEAD_REF}`);
-
   if (GITHUB_HEAD_REF) {
     channelID = GITHUB_HEAD_REF.split('/')
       .filter(item => item.trim().length > 0)
       .pop();
   }
-
-  console.log(`channelID: ${channelID}`);
 
   firebase
     .hosting


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
When PRs are manually deployed by number (by maintainers/contributors), static site is built from PR branch, but is deployed with the script from the branch on which the workflow was run.

This prevents:
- deploy failures caused by PRs on branches/forks with outdated deploy scripts
- malicious changes made to deploy script being run on a fork

PRs from contributors and maintainers still use all source code from their PR branch (including deploy script and automations).


(Also, cleans up a couple of print statements no longer needed for debugging.)

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
