### PR TITLE
Add instructions for using alternative Java Native Image Toolkit provider buildpacks

### DIFF
--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -233,6 +233,34 @@ pack build samples/jar --buildpack paketo-buildpacks/ca-certificates --buildpack
 
 It does not hurt to use this command for all situations, it is just more verbose and most users can get away without specifying the CA certificates buildpack to be first.
 
+## Use an Alternative Java Native Image Toolkit
+
+By default, the [Paketo Java Native Image buildpack][bp/java-native-image] will use the GraalVM Native Image Toolkit. The following Paketo JVM buildpacks may be used to substitute alternate Native Image Toolkit implemenations in place of the default.
+
+| JVM                                                                       | Buildpack                                                  |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| [Bellsoft Liberica](https://bell-sw.com/pages/liberica-native-image-kit/) | [Paketo Bellsoft Liberica Buildpack][bp/bellsoft-liberica] |
+
+To use an alternative Java Native Image Toolkit, you will need to set two `--buildpack` arguments to `pack build`, one for the alternative Java Native Image Toolkit buildpack you'd like to use and one for the Paketo Java Native Image buildpack (in that order). This works because while you end up with two Java Native Image Toolkit buildpacks, the first one, the one you're specifying will claim the build plan entries so the second one will end up being a noop and doing nothing.
+
+This example will switch in the Bellsoft Liberica buildpack:
+
+{{< code/copyable >}}
+pack build samples/native-image --buildpack paketo-buildpacks/bellsoft-liberica --buildpack paketo-buildpacks/java-native-image`
+{{< /code/copyable >}}
+
+There is one drawback to this approach. When using the method above to specify an alternative Java Native Image Toolkit vendor buildpack, this alternate buildpack ends up running before the CA certs buildpack and therefore traffic from the alternate Java Native Image Toolkit vendor buildpack won’t trust any additional CA certs. This is not expected to impact many users because Java Native Image Toolkit buildpacks should reach out to URLs that have a cert signed by a known authority with a CA in the default system truststore.
+
+If you have customized your Java Native Image Toolkit buildpack to download the Java Native Image Toolkit from a URL that uses a certificate not signed by a well-known CA, you can workaround this by specifying the CA certs buildpack to run first. This works because while you will end up with the CA certificates buildpack specified twice, the lifecycle is smart enough to drop the second one.
+
+For example:
+
+{{< code/copyable >}}
+pack build samples/jar --buildpack paketo-buildpacks/ca-certificates --buildpack paketo-buildpacks/bellsoft-liberica --buildpack paketo-buildpacks/java-native-image`
+{{< /code/copyable >}}
+
+It does not hurt to use this command for all situations, it is just more verbose and most users can get away without specifying the CA certificates buildpack to be first.
+
 ## Build a Spring Boot Application
 
 ### Inspect Spring Boot Application Dependencies


### PR DESCRIPTION
## Summary

With bellsoft-liberica 8.4.0 we now supply the Java Native Image toolkit. You can use this as an alternative to GraalVM, which is still the default in java-native-image.

## Use Cases

This PR adds instructions for using alternative Java Native Image Toolkit. There is presently one alternative, Bellsoft Liberica.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
