### PR TITLE
Use docs sidebar only on wider screens

### DIFF
--- a/assets/css/docs.scss
+++ b/assets/css/docs.scss
@@ -3,7 +3,7 @@
     display: block;
     background: $light-background-color;
 
-    @media (min-width: $header-hamburger-breakpoint) {
+    @media (min-width: $docs-sidebar-breakpoint) {
         display: flex;
     }
 }
@@ -15,7 +15,7 @@
     padding-top: 28px;
     background: $dark-background-color;
     
-    @media (min-width: $header-hamburger-breakpoint) {
+    @media (min-width: $docs-sidebar-breakpoint) {
         width: 380px;
         padding-top: 50px;
         padding-left: 50px;
@@ -122,7 +122,7 @@
     position: absolute;
     right: 20px;
 
-    @media (min-width: $header-hamburger-breakpoint) {
+    @media (min-width: $docs-sidebar-breakpoint) {
         right: 0px;
     }
 }
@@ -175,7 +175,7 @@
     color: $link-text-color;
 }
 
-@media (min-width: $header-hamburger-breakpoint) {
+@media (min-width: $docs-sidebar-breakpoint) {
     .docs-menu {
 		padding-bottom: 0px;
 	}
@@ -200,7 +200,7 @@
     padding-top: 40px;
     padding-bottom: 40px;
 
-    @media (min-width: $header-hamburger-breakpoint) {
+    @media (min-width: $docs-sidebar-breakpoint) {
         width: calc(100% - 380px);
         display: flex;
         flex-direction: row;

--- a/assets/css/variables.scss
+++ b/assets/css/variables.scss
@@ -4,6 +4,7 @@ $mobile-breakpoint-footer: 800px;
 $header-hamburger-breakpoint: 800px;
 $table-of-contents-breakpoint: 1200px;
 $action-buttons-breakpoint: 650px;
+$docs-sidebar-breakpoint: 1000px;
 
 /* color variables */
 $light-text-color : #ffffff;


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
It bothers me that sometimes the docs sidebar squishes the main docs content such that practically half of the docs page is sidebar:
![image](https://user-images.githubusercontent.com/21328286/131748571-4f76e2a2-2a26-4cc8-bfc9-cec7d89d00cb.png)


This PR sets a new screen width breakpoint for the docs sidebar and makes it larger, so that the smallest docs to sidebar ratio looks like:
![image](https://user-images.githubusercontent.com/21328286/131748522-cb323b88-88fc-49eb-837c-ffe784df01ca.png)

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
