### PR TITLE
fix npm file not found error in deploy workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -33,13 +33,8 @@ jobs:
         hugo-version: '0.84.0'
         extended: true
 
-    - run: cd build-environment
-
-    - name: Install node modules
-      run: npm install
-
     - name: Build
-      run: hugo
+      run: cd build-environment && npm install && hugo
 
     - name: Update
       run: |


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Deploy to prod has started [failing](https://github.com/paketo-buildpacks/paketo-website/runs/3589405533?check_suite_focus=true) after [this change](https://github.com/paketo-buildpacks/paketo-website/commit/b30d460e0976c9ad6cfd1dde7eb2a8b0f0bc9247#diff-4ce342fb97e7d7feb8a578c91ba89fe4c27ddf16b4306909fe6d90220141913d) to the workflow. This fixes that bug. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
