### PR TITLE
Adds the Adoptium buildpack (formerly AdoptOpenJDK) 

### DIFF
--- a/assets/css/text.scss
+++ b/assets/css/text.scss
@@ -167,6 +167,16 @@ table {
     white-space: nowrap;
 }
 
+.sub {
+    vertical-align: sub;
+    font-size: medium;
+}
+
+.sup {
+    vertical-align:super;
+    font-size: medium;
+}
+
 .text--light {
     color: $light-text-color;
 }

--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -202,20 +202,20 @@ See the [homepage][bp/bellsoft-liberica] for the Bellsoft Liberica Buildpack for
 
 By default, the [Paketo Java buildpack][bp/java] will use the Liberica JVM. The following Paketo JVM buildpacks may be used to substitute alternate JVM implemenations in place of Liberica's JVM.
 
-| JVM                                                                   | Buildpack                                                            |
-| --------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| [Adoptium](https://adoptium.net/) <sup>[1]</sup>                      | [Paketo Adoptium Buildpack][bp/adoptium]                             |
-| [Alibaba Dragonwell](http://dragonwell-jdk.io/) <sup>[2]</sup>        | [Paketo Alibaba Dragonwell Buildpack][bp/dragonwell]                 |
-| [Amazon Corretto](https://aws.amazon.com/corretto/) <sup>[2]</sup>    | [Paketo Amazon Corretto Buildpack][bp/amazon-corretto]               |
-| [Azul Zulu](https://www.azul.com/downloads/zulu-community/)           | [Paketo Azul Zulu Buildpack][bp/azul-zulu]                           |
-| [BellSoft Liberica](https://bell-sw.com/pages/libericajdk/)           | [Paketo BellSoft Liberica Buildpack - Default][bp/bellsoft-liberica] |
-| [Eclipse OpenJ9](https://www.eclipse.org/openj9/)                     | [Paketo Eclipse OpenJ9 Buildpack][bp/eclipse-openj9]                 |
-| [GraalVM](https://www.graalvm.org/) <sup>[2]</sup>                    | [Paketo GraalVM Buildpack][bp/graalvm]                               |
-| [Microsoft OpenJDK](https://www.microsoft.com/openjdk) <sup>[2]</sup> | [Paketo Microsoft OpenJDK Buildpack][bp/microsoft]                   |
-| [SapMachine](https://sap.github.io/SapMachine/)                       | [Paketo SapMachine Buildpack][bp/sap-machine]                        |
+| JVM                                                                                       | Buildpack                                                            |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [Adoptium](https://adoptium.net/) {{< text/sup >}}1{{< /text/sup >}}                      | [Paketo Adoptium Buildpack][bp/adoptium]                             |
+| [Alibaba Dragonwell](http://dragonwell-jdk.io/) {{< text/sup >}}2{{< /text/sup >}}        | [Paketo Alibaba Dragonwell Buildpack][bp/dragonwell]                 |
+| [Amazon Corretto](https://aws.amazon.com/corretto/) {{< text/sup >}}2{{< /text/sup >}}    | [Paketo Amazon Corretto Buildpack][bp/amazon-corretto]               |
+| [Azul Zulu](https://www.azul.com/downloads/zulu-community/)                               | [Paketo Azul Zulu Buildpack][bp/azul-zulu]                           |
+| [BellSoft Liberica](https://bell-sw.com/pages/libericajdk/)                               | [Paketo BellSoft Liberica Buildpack - Default][bp/bellsoft-liberica] |
+| [Eclipse OpenJ9](https://www.eclipse.org/openj9/)                                         | [Paketo Eclipse OpenJ9 Buildpack][bp/eclipse-openj9]                 |
+| [GraalVM](https://www.graalvm.org/) {{< text/sup >}}2{{< /text/sup >}}                    | [Paketo GraalVM Buildpack][bp/graalvm]                               |
+| [Microsoft OpenJDK](https://www.microsoft.com/openjdk) {{< text/sup >}}2{{< /text/sup >}} | [Paketo Microsoft OpenJDK Buildpack][bp/microsoft]                   |
+| [SapMachine](https://sap.github.io/SapMachine/)                                           | [Paketo SapMachine Buildpack][bp/sap-machine]                        |
 
-<sub>[1] - Only provides JRE and JDK releases for Java 8 and 11, Java 16+ is JDK only</sub>
-<sub>[2] - Only provides JDK releases</sub>
+1. *{{< text/sub >}}Only provides JRE and JDK releases for Java 8 and 11, Java 16+ is JDK only{{< /text/sub >}}*
+2. *{{< text/sub >}}Only provides JDK releases{{< /text/sub >}}*
 
 To use an alternative JVM, you will need to set two `--buildpack` arguments to `pack build`, one for the alternative JVM buildpack you'd like to use and one for the Paketo Java buildpack (in that order). This works because while you end up with two JVM buildpacks, the first one, the one you're specifying will claim the build plan entries so the second one will end up being a noop and doing nothing.
 

--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -202,16 +202,20 @@ See the [homepage][bp/bellsoft-liberica] for the Bellsoft Liberica Buildpack for
 
 By default, the [Paketo Java buildpack][bp/java] will use the Liberica JVM. The following Paketo JVM buildpacks may be used to substitute alternate JVM implemenations in place of Liberica's JVM.
 
-| JVM                                                         | Buildpack                                                            |
-| ----------------------------------------------------------- | -------------------------------------------------------------------- |
-| [Alibaba Dragonwell](http://dragonwell-jdk.io/)             | [Paketo Alibaba Dragonwell Buildpack][bp/dragonwell]                 |
-| [Amazon Corretto](https://aws.amazon.com/corretto/)         | [Paketo Amazon Corretto Buildpack][bp/amazon-corretto]               |
-| [Azul Zulu](https://www.azul.com/downloads/zulu-community/) | [Paketo Azul Zulu Buildpack][bp/azul-zulu]                           |
-| [BellSoft Liberica](https://bell-sw.com/pages/libericajdk/) | [Paketo BellSoft Liberica Buildpack - Default][bp/bellsoft-liberica] |
-| [Eclipse OpenJ9](https://www.eclipse.org/openj9/)           | [Paketo Eclipse OpenJ9 Buildpack][bp/eclipse-openj9]                 |
-| [GraalVM](https://www.graalvm.org/)                         | [Paketo GraalVM Buildpack][bp/graalvm]                               |
-| [Microsoft OpenJDK](https://www.microsoft.com/openjdk)      | [Paketo Microsoft OpenJDK Buildpack][bp/microsoft]                   |
-| [SapMachine](https://sap.github.io/SapMachine/)             | [Paketo SapMachine Buildpack][bp/sap-machine]                        |
+| JVM                                                                   | Buildpack                                                            |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [Adoptium](https://adoptium.net/) <sup>[1]</sup>                      | [Paketo Adoptium Buildpack][bp/adoptium]                             |
+| [Alibaba Dragonwell](http://dragonwell-jdk.io/) <sup>[2]</sup>        | [Paketo Alibaba Dragonwell Buildpack][bp/dragonwell]                 |
+| [Amazon Corretto](https://aws.amazon.com/corretto/) <sup>[2]</sup>    | [Paketo Amazon Corretto Buildpack][bp/amazon-corretto]               |
+| [Azul Zulu](https://www.azul.com/downloads/zulu-community/)           | [Paketo Azul Zulu Buildpack][bp/azul-zulu]                           |
+| [BellSoft Liberica](https://bell-sw.com/pages/libericajdk/)           | [Paketo BellSoft Liberica Buildpack - Default][bp/bellsoft-liberica] |
+| [Eclipse OpenJ9](https://www.eclipse.org/openj9/)                     | [Paketo Eclipse OpenJ9 Buildpack][bp/eclipse-openj9]                 |
+| [GraalVM](https://www.graalvm.org/) <sup>[2]</sup>                    | [Paketo GraalVM Buildpack][bp/graalvm]                               |
+| [Microsoft OpenJDK](https://www.microsoft.com/openjdk) <sup>[2]</sup> | [Paketo Microsoft OpenJDK Buildpack][bp/microsoft]                   |
+| [SapMachine](https://sap.github.io/SapMachine/)                       | [Paketo SapMachine Buildpack][bp/sap-machine]                        |
+
+<sub>[1] - Only provides JRE and JDK releases for Java 8 and 11, Java 16+ is JDK only</sub>
+<sub>[2] - Only provides JDK releases</sub>
 
 To use an alternative JVM, you will need to set two `--buildpack` arguments to `pack build`, one for the alternative JVM buildpack you'd like to use and one for the Paketo Java buildpack (in that order). This works because while you end up with two JVM buildpacks, the first one, the one you're specifying will claim the build plan entries so the second one will end up being a noop and doing nothing.
 
@@ -456,6 +460,7 @@ pack build samples/native -e BP_NATIVE_IMAGE=true --buildpack gcr.io/paketo-buil
 {{< /code/copyable >}}
 
 <!-- buildpacks -->
+[bp/adoptium]:https://github.com/paketo-buildpacks/adoptium
 [bp/amazon-corretto]:https://github.com/paketo-buildpacks/amazon-corretto
 [bp/apache-tomcat]:https://github.com/paketo-buildpacks/apache-tomcat
 [bp/azul-zulu]:https://github.com/paketo-buildpacks/azul-zulu

--- a/layouts/shortcodes/text/sub.html
+++ b/layouts/shortcodes/text/sub.html
@@ -1,0 +1,1 @@
+<span class="sub">{{ .Inner }}</span>

--- a/layouts/shortcodes/text/sup.html
+++ b/layouts/shortcodes/text/sup.html
@@ -1,0 +1,1 @@
+<span class="sup">{{ .Inner }}</span>


### PR DESCRIPTION
…and clarifies which alternative JVMs include JREs/JDKs

## Summary

AdoptOpenJDK was never added to the list. It has since been renamed Adoptium. Adding Adoptium.

We also have some JRE Providers that do not supply both a JRE and a JDK. This lists which ones provide both and which ones are limited.

## Use Cases

Provide more detail about our alternative JVM providers.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
