### PR TITLE
Added info on new Java features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /public
 /node_modules
 /resources
+.history/
 .firebase/
 .DS_Store
 .bin/

--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -461,6 +461,13 @@ If any args are provided via `BPL_JFR_ARGS`, these defaults will not be configur
 
 **Example**: Enabling & configuring JFR
 
+The following command builds a JFR-enabled image.
+
+{{< code/copyable >}}
+pack build samples/java \
+  --path java/jar
+{{< /code/copyable >}}
+
 To run an image with JFR enabled and optionally configure it with custom arguments:
 
 {{< code/copyable >}}

--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -419,6 +419,13 @@ If `BPL_JMX_ENABLED` is set at runtime, the application will be configured to ac
 
 **Example**: Enabling JMX
 
+The following command builds a JMX-enabled image.
+
+{{< code/copyable >}}
+pack build samples/java \
+  --path java/jar 
+{{< /code/copyable >}}
+
 To run an image with the JMX port published:
 {{< code/copyable >}}
 docker run --env BPL_JMX_ENABLED=true --publish 5000:5000 samples/java

--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -398,6 +398,13 @@ If `BPL_DEBUG_ENABLED` is set to `true` at runtime the application will be confi
 
 **Example**: Remote Debugging
 
+The following command builds a debug-enabled image.
+
+{{< code/copyable >}}
+pack build samples/java \
+  --path java/jar
+{{< /code/copyable >}}
+
 To run an image with the debug port published:
 {{< code/copyable >}}
 docker run --env BPL_DEBUG_ENABLED=true --publish 8000:8000 samples/java

--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -436,7 +436,7 @@ Connect [JConsole][jconsole] to the published port.
   
 ## Enable Java Native Memory Tracking (NMT)
 
-By default, the JVM will be configured track internal memory usage. The JVM will print its last memory usage data when it exits, the level of detail can be configured at runtime by setting the environment variable `BPL_JAVA_NMT_LEVEL`, which supports both `summary` (default) and `detail`. Since there is a small amount of overhead required to support NMT, it can be disabled by setting the environment variable `BPL_JAVA_NMT_ENABLED` to `false`.
+By default, the JVM will be configured to track internal memory usage. The JVM will print its last memory usage data when it exits, the level of detail can be configured at runtime by setting the environment variable `BPL_JAVA_NMT_LEVEL`, which supports both `summary` (default) and `detail`. Since there is a small amount of overhead required to support NMT, it can be disabled by setting the environment variable `BPL_JAVA_NMT_ENABLED` to `false`.
   
 **Example**: Capturing NMT output
 

--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -440,7 +440,15 @@ By default, the JVM will be configured to track internal memory usage. The JVM w
   
 **Example**: Capturing NMT output
 
-To capture NMT data using the JDK tool `jcmd`, first ensure that you have a JDK installed at runtime (see [Install a Specific JVM Type][install-jvm-type]). Then run the following from within the container: 
+To capture NMT data using the JDK tool `jcmd`, first ensure that you have a JDK installed at runtime (see [Install a Specific JVM Type][install-jvm-type]). 
+
+Then run the following to start a bash session on a running container, with `jcmd` available on the $PATH variable: 
+
+{{< code/copyable >}}
+docker exec -it <container-id> /cnb/lifecycle/launcher /bin/bash
+{{< /code/copyable >}}
+
+From inside the new bash session, you can run the following to view the NMT data:
 
 {{< code/copyable >}}
 jcmd 1 VM.native_memory summary
@@ -450,7 +458,7 @@ The first argument should be the JVM PID, in the case of the Paketo Java buildpa
 
 ## Enable Java Flight Recorder (JFR)
 
-If `BPL_JFR_ENABLED` is set to `true` at runtime, Java Flight Recording features will be enabled by the JVM. To configure JFR via it's supported arguments, add them to the optional environment variable `BPL_JFR_ARGS` at runtime.
+If `BPL_JFR_ENABLED` is set to `true` at runtime, Java Flight Recording features will be enabled by the JVM. To configure JFR via [its supported arguments](https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/run.htm#JFRUH178), add them to the optional environment variable `BPL_JFR_ARGS` at runtime.
 
 Two default arguments are configured for JFR as follows:
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This PR updates the following Java How-To sections, separate buildpacks are no longer needed for these features as they are provided by `libjvm` and can be enabled at runtime

* JMX
* Remote Debug

There are new sections for the following features:

* Native Memory Tracking (NMT)
* Flight Recording (JFR)
* Install a Specific JVM Type

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
