### PR TITLE
Links should use HTTPS

### DIFF
--- a/content/docs/howto/configuration.md
+++ b/content/docs/howto/configuration.md
@@ -357,7 +357,7 @@ This isn't always necessary but can impact output from your application. For exa
 [k8s service bindings]:https://github.com/k8s-service-bindings/spec
 [kpack service bindings]:https://github.com/pivotal/kpack/blob/master/docs/servicebindings.md#service-bindings
 [liberica releases]:https://github.com/bell-sw/Liberica/releases
-[maven settings]:http://maven.apache.org/settings.html
+[maven settings]:https://maven.apache.org/settings.html
 [maven opts]:https://maven.apache.org/configure.html#maven_opts-environment-variable
 [oci annotation keys]:https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
 [spring cloud bindings]:https://github.com/spring-cloud/spring-cloud-bindings

--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -215,7 +215,7 @@ By default, the [Paketo Java buildpack][bp/java] will use the Liberica JVM. The 
 | JVM                                                                                                                                     | Buildpack                                                            |
 | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | [Adoptium](https://adoptium.net/) {{< text/sup >}}1{{< /text/sup >}}                                                                    | [Paketo Adoptium Buildpack][bp/adoptium]                             |
-| [Alibaba Dragonwell](http://dragonwell-jdk.io/) {{< text/sup >}}2{{< /text/sup >}}                                                      | [Paketo Alibaba Dragonwell Buildpack][bp/dragonwell]                 |
+| [Alibaba Dragonwell](https://github.com/alibaba/dragonwell8) {{< text/sup >}}2{{< /text/sup >}}                                                      | [Paketo Alibaba Dragonwell Buildpack][bp/dragonwell]                 |
 | [Amazon Corretto](https://aws.amazon.com/corretto/) {{< text/sup >}}2{{< /text/sup >}}                                                  | [Paketo Amazon Corretto Buildpack][bp/amazon-corretto]               |
 | [Azul Zulu](https://www.azul.com/downloads/zulu-community/)                                                                             | [Paketo Azul Zulu Buildpack][bp/azul-zulu]                           |
 | [BellSoft Liberica](https://bell-sw.com/pages/libericajdk/)                                                                             | [Paketo BellSoft Liberica Buildpack - Default][bp/bellsoft-liberica] |
@@ -663,7 +663,7 @@ Each argument provided to the launcher will be evaluated by the shell prior to e
 [platforms]:https://buildpacks.io/docs/concepts/components/platform/
 
 <!-- other references -->
-[apache tomcat]:http://tomcat.apache.org
+[apache tomcat]:https://tomcat.apache.org
 [apm]:https://en.wikipedia.org/wiki/Application_performance_management
 [azure application insights instrumentation key]:https://docs.microsoft.com/en-us/azure/azure-monitor/app/create-new-resource#copy-the-instrumentation-key
 [azure application insights]:https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
@@ -682,7 +682,7 @@ Each argument provided to the launcher will be evaluated by the shell prior to e
 [kubernetes container resource]:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core
 [leiningen]:https://leiningen.org/
 [liberica]:https://bell-sw.com/
-[maven settings]:http://maven.apache.org/settings.html
+[maven settings]:https://maven.apache.org/settings.html
 [maven]:https://maven.apache.org/
 [oci config]:https://github.com/opencontainers/image-spec/blob/master/config.md#properties
 [sbt]:https://www.scala-sbt.org/index.html

--- a/content/docs/reference/ruby-reference.md
+++ b/content/docs/reference/ruby-reference.md
@@ -34,18 +34,18 @@ application will be assigned when building your application container.
 
 ### Webservers
 
-* [Passenger](http://github.com/paketo-buildpacks/passenger)
-* [Puma](http://github.com/paketo-buildpacks/puma)
-* [Rackup](http://github.com/paketo-buildpacks/rackup)
-* [Thin](http://github.com/paketo-buildpacks/thin)
-* [Unicorn](http://github.com/paketo-buildpacks/unicorn)
+* [Passenger](https://github.com/paketo-buildpacks/passenger)
+* [Puma](https://github.com/paketo-buildpacks/puma)
+* [Rackup](https://github.com/paketo-buildpacks/rackup)
+* [Thin](https://github.com/paketo-buildpacks/thin)
+* [Unicorn](https://github.com/paketo-buildpacks/unicorn)
 
 ### Task Runners
 
-* [Rake](http://github.com/paketo-buildpacks/rake)
+* [Rake](https://github.com/paketo-buildpacks/rake)
 
 ## Rails Asset Pipeline
-The [Paketo Rails Assets Buildpack](http://github.com/paketo-buildpacks/rails-assets) is a [component buildpack]({{< ref "/docs/concepts/buildpacks#component-buildpacks" >}}) included in the Ruby Buildpack. It supports Rails apps (Rails version >= 5.0) that need asset precompilation.
+The [Paketo Rails Assets Buildpack](https://github.com/paketo-buildpacks/rails-assets) is a [component buildpack]({{< ref "/docs/concepts/buildpacks#component-buildpacks" >}}) included in the Ruby Buildpack. It supports Rails apps (Rails version >= 5.0) that need asset precompilation.
 
 The buildpack runs bundle exec rails assets:precompile for the app, and works with any of the supported Ruby webservers listed above.
 


### PR DESCRIPTION
This change ensures that HTTPS is used for links instead of HTTP. But I have a quick question @paketo-buildpacks/content-maintainers

The `Alibaba Dragonwell` link in [content/docs/howto/java.md](https://github.com/paketo-buildpacks/paketo-website/commit/446e372e79e2512f1f919a6fed9c18a25556d2ea#diff-3668d490584ee44201a09343fe07b10214024909af669ef8e49a8fa8704f9bd7R218) does not work with HTTPS. Should the link be removed from the site?