### PR TITLE
Fix copy code feature

### DIFF
--- a/assets/css/docs.scss
+++ b/assets/css/docs.scss
@@ -433,11 +433,13 @@
 	padding: 0.35em 0.6em;
 	border: 1px solid #E4E4E4;
     border-radius: 5px;
-	overflow: auto;
 }
 
 .copyable__code {
     font-family: monospace;
+    word-spacing: normal;
+    color: #16819c;
+    overflow: auto;
 }
 
 .copyable__clipboard {
@@ -454,30 +456,14 @@
     display: block;
 }
 
-.copyable--clicked .copyable__clipboard {
-    display: none;
-}
-
-.copyable--clicked:hover .copyable__clipboard {
-    display: none;
-}
-
 .copyable__copied {
     visibility: hidden;
 	position: absolute;
-	top: 2px;
+	top: 25px;
 	right: 2px;
     background-color: $light-background-color;
     opacity: 100;
     font-family: $default-font-family;
-}
-
-.copyable--clicked .copyable__clipboard {
-    display: none;
-}
-
-.copyable--clicked:hover .copyable__clipboard {
-    display: none;
 }
 
 .copyable--clicked .copyable__copied {
@@ -504,7 +490,7 @@
     .copyable__copied {
         visibility: hidden;
         position: absolute;
-        top: 2px;
+        top: 25px;
         right: 2px;
         background-color: $light-background-color;
         opacity: 100;

--- a/assets/css/shame.scss
+++ b/assets/css/shame.scss
@@ -20,19 +20,7 @@ Frankie GJ 9/13/21 */
 that shouldn't apply to the click to copy clipboard
 Frankie GJ 9/13/21  */
 :root .copyable__clipboard {
-	display: block;
 	border: none;
-}
-
-/* Since the above uses :root, these ones also have to
-so that the click-to-copy JS can update the classes and 
-make a visible impact
-Frankie GJ 9/13/21  */
-:root .copyable--clicked .copyable__clipboard {
-	display: none;
-}
-:root .copyable--clicked:hover .copyable__clipboard {
-	display: none;
 }
 
 /* Without this, the docs-menu__link hover state color overrides

--- a/assets/js/components/code_snippet.js
+++ b/assets/js/components/code_snippet.js
@@ -23,8 +23,14 @@ class Clipboard {
   }
 
   handleClick() {
+    // Prevent spamming
+    if (this.element.classList.contains('copyable--clicked')) {
+      return;
+    }
+
     ClipboardJS.copy(this.code);
     this.element.classList.add('copyable--clicked');
+    setTimeout(() => { this.element.classList.toggle('copyable--clicked')}, 1900);
   }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -24,7 +24,7 @@ window.addEventListener('load', (event) => {
     hostname: window.location.hostname,
   });
 
-  for (const element of document.querySelectorAll('.docs pre')) {
+  for (const element of document.querySelectorAll('.copyable')) {
     new CodeSnippet({ element: element });
   }
 

--- a/layouts/shortcodes/code/copyable.html
+++ b/layouts/shortcodes/code/copyable.html
@@ -1,1 +1,5 @@
-<pre class="copyable"><code class="copyable__code">{{ strings.TrimLeft "\n" .Inner }}</code><img class="copyable__clipboard" src="/images/clipboard.svg" alt="copy to clipboard" /><div class="copyable__copied copied">Copied!</div></pre>
+<div class="copyable">
+    <pre class="copyable__code">{{ strings.TrimLeft "\n" .Inner }}</pre>
+    <img class="copyable__clipboard" src="/images/clipboard.svg" alt="copy to clipboard" />
+    <div class="copyable__copied copied">Copied!</div>
+</div>


### PR DESCRIPTION
This fixes the copy feature so that the paste icon does not move when the code is scrolled horizontally and the paste icon does not disappear when clicked.