### PR TITLE
Add GraalVM 21.3 to the versions chart

### DIFF
--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -317,6 +317,7 @@ The following table documents the versions available.
 
 | GraalVM Version | Java Native Image Buildpack Version |
 | --------------- | ----------------------------------- |
+| 21.3            | 5.12.0                              |
 | 21.2            | 5.5.0                               |
 | 21.1            | 5.4.0                               |
 | 21.0            | 5.3.0                               |


### PR DESCRIPTION
## Summary

Add an entry to the table for GraalVM 21.3.

## Use Cases

For users wishing to use an older version of GraalVM, we maintain a table of buildpack versions that provide a specific GraalVM version. This updates that table to include the latest GraalVM version.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
