### PR TITLE
Add PHP docs site to link check excludelist

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -127,7 +127,8 @@ check_links() {
 
   # A list of URL patterns that we know are correct but fail to be scraped
   # These are usually sites where anchor links are rendered by Javascript in-browser
-  excludeList=( "github\\.com.*#" "maven\\.apache\\.org.*#"
+  excludeList=( "github\\.com.*#"
+    "maven\\.apache\\.org.*#"
     "docs\\.npmjs\\.com.*#"
     "github\\.com\\/paketo-buildpacks\\/paketo-website\\/edit"
     "www\\.php\\.net\\/manual\\/en"

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -127,7 +127,11 @@ check_links() {
 
   # A list of URL patterns that we know are correct but fail to be scraped
   # These are usually sites where anchor links are rendered by Javascript in-browser
-  excludeList=( "github\\.com.*#" "maven\\.apache\\.org.*#" "docs\\.npmjs\\.com.*#" "github\\.com\\/paketo-buildpacks\\/paketo-website\\/edit" )
+  excludeList=( "github\\.com.*#" "maven\\.apache\\.org.*#"
+    "docs\\.npmjs\\.com.*#"
+    "github\\.com\\/paketo-buildpacks\\/paketo-website\\/edit"
+    "www\\.php\\.net\\/manual\\/en"
+  )
 
   excludeGithub=""
   limitConnections="--max-connections=1"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
For some reason, the PHP docs site consistently fails the muffet link check. See https://github.com/raviqqe/muffet/issues/184.  If/when that bug is resolved, the site could be removed from the excludelist.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
