### PR TITLE
Add missing references to language-specific docs

### DIFF
--- a/content/getting-started-languages/dotnet_core.md
+++ b/content/getting-started-languages/dotnet_core.md
@@ -172,3 +172,6 @@ You've done it! As you can see, Paketo buildpacks do most of the hard work for y
 Check out more [sample apps](https://github.com/paketo-buildpacks/samples) that work with Paketo Buildpacks.
 
 Keep reading to learn about Paketo Builders, the Cloud Native Buildpack API, and what Paketo Buildpacks are doing under the hood to make it easy to build your apps.
+
+[install-docker]:https://docs.docker.com/get-docker/
+[install-pack]:https://buildpacks.io/docs/install-pack/

--- a/content/getting-started-languages/java.md
+++ b/content/getting-started-languages/java.md
@@ -201,3 +201,5 @@ Check out more [sample apps](https://github.com/paketo-buildpacks/samples) that 
 
 Keep reading to learn about Paketo Builders, the Cloud Native Buildpack API, and what Paketo Buildpacks are doing under the hood to make it easy to build your apps.
 
+[install-docker]:https://docs.docker.com/get-docker/
+[install-pack]:https://buildpacks.io/docs/install-pack/

--- a/content/getting-started-languages/nodejs.md
+++ b/content/getting-started-languages/nodejs.md
@@ -138,3 +138,6 @@ You've done it! As you can see, Paketo buildpacks do most of the hard work for y
 Check out more [sample apps](https://github.com/paketo-buildpacks/samples) that work with Paketo Buildpacks.
 
 Keep reading to learn about Paketo Builders, the Cloud Native Buildpack API, and what Paketo Buildpacks are doing under the hood to make it easy to build your apps.
+
+[install-docker]:https://docs.docker.com/get-docker/
+[install-pack]:https://buildpacks.io/docs/install-pack/

--- a/content/getting-started-languages/python.md
+++ b/content/getting-started-languages/python.md
@@ -157,3 +157,6 @@ curl http://localhost:8080/
 {{< /code/output >}}
 
 You can also visit `http://localhost:8080` with your browser to see the app's homepage.
+
+[install-docker]:https://docs.docker.com/get-docker/
+[install-pack]:https://buildpacks.io/docs/install-pack/


### PR DESCRIPTION
These references are missing and the getting started guides are missing the link to install Pack CLI. It was not obvious without the link where to find Pack CLI. It looks like hugo doesn't actually pick up the links in footer through the parent page, when the language-specific version of these instructions gets broken out into separate docs.

Testing this change locally it appears to resolve the broken link.