### PR TITLE
Use npm ci when deploying dev PRs

### DIFF
--- a/.github/workflows/deploy-dev-pr.yml
+++ b/.github/workflows/deploy-dev-pr.yml
@@ -46,7 +46,7 @@ jobs:
         extended: true
 
     - name: Install node Modules
-      run: npm install
+      run: npm ci
 
     - name: Setup GCP Auth
       id: auth


### PR DESCRIPTION
so there aren't merge conflicts switching from PR branch to main

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->
To avoid CI failures like [this one](https://github.com/paketo-buildpacks/paketo-website/runs/5556264804?check_suite_focus=true) where the deploy PR workflow fails to switch between PR branch and main branch because `npm install` has changed the lockfile.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
