### PR TITLE
Use Dockerhub refs for buildpacks

### DIFF
--- a/content/docs/howto/configuration.md
+++ b/content/docs/howto/configuration.md
@@ -198,8 +198,8 @@ The following adds a process with `type` equal to `hello` and makes it the defau
 echo "hello: echo hello world" > nodejs/yarn/Procfile
 pack build samples/nodejs \
   --path nodejs/yarn \
-  --buildpack paketobuildpacks/nodejs:latest \
-  --buildpack gcr.io/paketo-buildpacks/procfile:latest \
+  --buildpack paketo-buildpacks/nodejs \
+  --buildpack paketo-buildpacks/procfile \
   --default-process hello
 docker run samples/nodejs # should print "hello world"
 {{< /code/copyable >}}
@@ -299,8 +299,8 @@ If a given [language family buildpack][language family buildpacks] does not cont
 {{< code/copyable >}}
 pack build samples/nodejs \
   --path nodejs/yarn \
-  --buildpack paketobuildpacks/nodejs:latest \
-  --buildpack gcr.io/paketo-buildpacks/procfile:latest \
+  --buildpack paketo-buildpacks/nodejs \
+  --buildpack paketo-buildpacks/image-labels \
   --env "BP_OCI_DESCRIPTION=Demo Application" \
   --env 'BP_IMAGE_LABELS=io.packeto.example="Adding Custom Labels"'
 docker inspect samples/nodejs | jq '.[].Config.Labels["org.opencontainers.image.description"]' # should print "Demo Application"

--- a/content/docs/howto/configuration.md
+++ b/content/docs/howto/configuration.md
@@ -198,8 +198,8 @@ The following adds a process with `type` equal to `hello` and makes it the defau
 echo "hello: echo hello world" > nodejs/yarn/Procfile
 pack build samples/nodejs \
   --path nodejs/yarn \
-  --buildpack gcr.io/paketo-buildpacks/nodejs \
-  --buildpack gcr.io/paketo-buildpacks/procfile \
+  --buildpack paketobuildpacks/nodejs:latest \
+  --buildpack gcr.io/paketo-buildpacks/procfile:latest \
   --default-process hello
 docker run samples/nodejs # should print "hello world"
 {{< /code/copyable >}}
@@ -299,8 +299,8 @@ If a given [language family buildpack][language family buildpacks] does not cont
 {{< code/copyable >}}
 pack build samples/nodejs \
   --path nodejs/yarn \
-  --buildpack  gcr.io/paketo-buildpacks/nodejs \
-  --buildpack  gcr.io/paketo-buildpacks/image-labels \
+  --buildpack paketobuildpacks/nodejs:latest \
+  --buildpack gcr.io/paketo-buildpacks/procfile:latest \
   --env "BP_OCI_DESCRIPTION=Demo Application" \
   --env 'BP_IMAGE_LABELS=io.packeto.example="Adding Custom Labels"'
 docker inspect samples/nodejs | jq '.[].Config.Labels["org.opencontainers.image.description"]' # should print "Demo Application"

--- a/content/docs/howto/dotnet-core.md
+++ b/content/docs/howto/dotnet-core.md
@@ -17,7 +17,7 @@ To build your app locally with the buildpack using the `pack` CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/dotnet-core/aspnet
-pack build my-app --buildpack gcr.io/paketo-buildpacks/dotnet-core \
+pack build my-app --buildpack paketobuildpacks/dotnet-core:latest \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
@@ -192,7 +192,7 @@ Set the `BP_DOTNET_PUBLISH_FLAGS` environment variable at build time to provide 
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_DOTNET_PUBLISH_FLAGS` at build time with the `--env` flag. For example, to add `--verbosity=normal` and `--self-contained=true` to the build flagset, set the environment variable as follows:
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/go \
+pack build my-app --buildpack paketobuildpacks/dotnet-core:latest \
   --env BP_DOTNET_PUBLISH_FLAGS="--verbosity=normal --self-contained=true"
 {{< /code/copyable >}}
 

--- a/content/docs/howto/dotnet-core.md
+++ b/content/docs/howto/dotnet-core.md
@@ -17,7 +17,7 @@ To build your app locally with the buildpack using the `pack` CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/dotnet-core/aspnet
-pack build my-app --buildpack paketobuildpacks/dotnet-core:latest \
+pack build my-app --buildpack paketo-buildpacks/dotnet-core \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
@@ -192,7 +192,7 @@ Set the `BP_DOTNET_PUBLISH_FLAGS` environment variable at build time to provide 
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_DOTNET_PUBLISH_FLAGS` at build time with the `--env` flag. For example, to add `--verbosity=normal` and `--self-contained=true` to the build flagset, set the environment variable as follows:
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/dotnet-core:latest \
+pack build my-app --buildpack paketo-buildpacks/dotnet-core \
   --env BP_DOTNET_PUBLISH_FLAGS="--verbosity=normal --self-contained=true"
 {{< /code/copyable >}}
 

--- a/content/docs/howto/go.md
+++ b/content/docs/howto/go.md
@@ -29,7 +29,7 @@ cd samples/go/mod
 
 1. Use the pack CLI with the Paketo Go Buildpack to build the sample app.
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/go:latest \
+pack build my-app --buildpack paketo-buildpacks/go \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
@@ -52,7 +52,7 @@ the buildpack will provide the default version, which can be seen in the
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_GO_VERSION` at build time with the `--env` flag.
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/go:latest \
+pack build my-app --buildpack paketo-buildpacks/go \
   --env BP_GO_VERSION="1.14.1"
 {{< /code/copyable >}}
 
@@ -80,7 +80,7 @@ The Paketo Go buildpack has a dedicated environment variable for setting the val
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_GO_BUILD_LDFLAGS` at build time with the `--env` flag. For example, to add `-ldflags="-X main.variable=some-value"` to the build flagset, set the environment variable as follows:
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/go:latest \
+pack build my-app --buildpack paketo-buildpacks/go \
   --env BP_GO_BUILD_LDFLAGS="-X main.variable=some-value"
 {{< /code/copyable >}}
 
@@ -102,7 +102,7 @@ Setting `BP_GO_BUILD_FLAGS` will add to the Paketo Go buildpack's default flagse
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_GO_BUILD_FLAGS` at build time with the `--env` flag. For example, to add `-buildmode=default -tags=paketo` to the build flagset, set the environment variable as follows:
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/go:latest \
+pack build my-app --buildpack paketo-buildpacks/go \
   --env BP_GO_BUILD_FLAGS="-buildmode=default -tags=paketo"
 {{< /code/copyable >}}
 
@@ -138,7 +138,7 @@ app-directory
 When building with the pack CLI, set `BP_GO_TARGETS` at build time with the `--env` flag. 
 
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/go:latest \
+pack build my-app --buildpack paketo-buildpacks/go \
   --env BP_GO_TARGETS="./second"
 {{< /code/copyable >}}
 
@@ -164,7 +164,7 @@ the app image. The following examples will build _both_ the `first` and `second`
 When building with the pack CLI, set `BP_GO_TARGETS` at build time with the `--env` flag. 
 
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/go:latest \
+pack build my-app --buildpack paketo-buildpacks/go \
   --env BP_GO_TARGETS="./first:./second"
 {{< /code/copyable >}}
 
@@ -205,7 +205,7 @@ password=<SERVICE ACCOUNT KEY>
 1. Provide the service binding and `$GOPRIVATE` environment variable at build
    time:
 {{< code/copyable >}}
-pack build myapp --buildpack paketobuildpacks/go:latest \
+pack build myapp --buildpack paketo-buildpacks/go \
                  --env GOPRIVATE="github.com/private-org/private-module" \
                  --env SERVICE_BINDING_ROOT="/bindings" \
                  --volume /tmp/git-binding:/bindings/git-binding
@@ -240,7 +240,7 @@ import (
 When building with the pack CLI, set `$BP_GO_BUILD_IMPORT_PATH` at build time with the `--env` flag. 
 
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/go:latest \
+pack build my-app --buildpack paketo-buildpacks/go \
   --env BP_GO_BUILD_IMPORT_PATH="github.com/app-developer/app-directory"
 {{< /code/copyable >}}
 
@@ -268,7 +268,7 @@ When building with the pack CLI, set `$BP_KEEP_FILES` at build time with the
 `--env` flag. 
 
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/go:latest \
+pack build my-app --buildpack paketo-buildpacks/go \
   --env BP_KEEP_FILES="assets/*:public/*"
 {{< /code/copyable >}}
 
@@ -314,7 +314,7 @@ You can use the Paketo Go buildpack with [Tilt][tilt]. This example
 uses the [`pack` extension][tilt/pack] for Tilt, and shows how to configure watched files.
 {{< code/copyable >}}
 pack('my-app',
-  buildpacks=["paketobuildpacks/go:latest"],
+  buildpacks=["paketo-buildpacks/go"],
   path='./src',
   env_vars=["BP_LIVE_RELOAD_ENABLED=true"],
   deps=['./src/build'],
@@ -378,7 +378,7 @@ build-time SBOM.
 1. When building with the pack CLI, use the flag `--sbom-output-dir` to extract
    SBOMs from the build:
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/go:latest \
+pack build my-app --buildpack paketo-buildpacks/go \
                   --sbom-output-dir /tmp/sbom-output
 {{< /code/copyable >}}
 2. To view the Go modules used in the build, inspect one of the SBOMs generated

--- a/content/docs/howto/go.md
+++ b/content/docs/howto/go.md
@@ -29,7 +29,7 @@ cd samples/go/mod
 
 1. Use the pack CLI with the Paketo Go Buildpack to build the sample app.
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/go \
+pack build my-app --buildpack paketobuildpacks/go:latest \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
@@ -52,7 +52,7 @@ the buildpack will provide the default version, which can be seen in the
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_GO_VERSION` at build time with the `--env` flag.
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/go \
+pack build my-app --buildpack paketobuildpacks/go:latest \
   --env BP_GO_VERSION="1.14.1"
 {{< /code/copyable >}}
 
@@ -80,7 +80,7 @@ The Paketo Go buildpack has a dedicated environment variable for setting the val
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_GO_BUILD_LDFLAGS` at build time with the `--env` flag. For example, to add `-ldflags="-X main.variable=some-value"` to the build flagset, set the environment variable as follows:
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/go \
+pack build my-app --buildpack paketobuildpacks/go:latest \
   --env BP_GO_BUILD_LDFLAGS="-X main.variable=some-value"
 {{< /code/copyable >}}
 
@@ -102,7 +102,7 @@ Setting `BP_GO_BUILD_FLAGS` will add to the Paketo Go buildpack's default flagse
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_GO_BUILD_FLAGS` at build time with the `--env` flag. For example, to add `-buildmode=default -tags=paketo` to the build flagset, set the environment variable as follows:
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/go \
+pack build my-app --buildpack paketobuildpacks/go:latest \
   --env BP_GO_BUILD_FLAGS="-buildmode=default -tags=paketo"
 {{< /code/copyable >}}
 
@@ -138,7 +138,7 @@ app-directory
 When building with the pack CLI, set `BP_GO_TARGETS` at build time with the `--env` flag. 
 
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/go \
+pack build my-app --buildpack paketobuildpacks/go:latest \
   --env BP_GO_TARGETS="./second"
 {{< /code/copyable >}}
 
@@ -164,7 +164,7 @@ the app image. The following examples will build _both_ the `first` and `second`
 When building with the pack CLI, set `BP_GO_TARGETS` at build time with the `--env` flag. 
 
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/go \
+pack build my-app --buildpack paketobuildpacks/go:latest \
   --env BP_GO_TARGETS="./first:./second"
 {{< /code/copyable >}}
 
@@ -205,7 +205,7 @@ password=<SERVICE ACCOUNT KEY>
 1. Provide the service binding and `$GOPRIVATE` environment variable at build
    time:
 {{< code/copyable >}}
-pack build myapp --buildpack gcr.io/paketo-buildpacks/go \
+pack build myapp --buildpack paketobuildpacks/go:latest \
                  --env GOPRIVATE="github.com/private-org/private-module" \
                  --env SERVICE_BINDING_ROOT="/bindings" \
                  --volume /tmp/git-binding:/bindings/git-binding
@@ -240,7 +240,7 @@ import (
 When building with the pack CLI, set `$BP_GO_BUILD_IMPORT_PATH` at build time with the `--env` flag. 
 
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/go \
+pack build my-app --buildpack paketobuildpacks/go:latest \
   --env BP_GO_BUILD_IMPORT_PATH="github.com/app-developer/app-directory"
 {{< /code/copyable >}}
 
@@ -268,7 +268,7 @@ When building with the pack CLI, set `$BP_KEEP_FILES` at build time with the
 `--env` flag. 
 
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/go \
+pack build my-app --buildpack paketobuildpacks/go:latest \
   --env BP_KEEP_FILES="assets/*:public/*"
 {{< /code/copyable >}}
 
@@ -314,7 +314,7 @@ You can use the Paketo Go buildpack with [Tilt][tilt]. This example
 uses the [`pack` extension][tilt/pack] for Tilt, and shows how to configure watched files.
 {{< code/copyable >}}
 pack('my-app',
-  buildpacks=["gcr.io/paketo-buildpacks/go"],
+  buildpacks=["paketobuildpacks/go:latest"],
   path='./src',
   env_vars=["BP_LIVE_RELOAD_ENABLED=true"],
   deps=['./src/build'],
@@ -378,7 +378,7 @@ build-time SBOM.
 1. When building with the pack CLI, use the flag `--sbom-output-dir` to extract
    SBOMs from the build:
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/go \
+pack build my-app --buildpack paketobuildpacks/go:latest \
                   --sbom-output-dir /tmp/sbom-output
 {{< /code/copyable >}}
 2. To view the Go modules used in the build, inspect one of the SBOMs generated

--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -234,7 +234,7 @@ To use an alternative JVM, you will need to set two `--buildpack` arguments to `
 This example will switch in the Azul Zulu buildpack:
 
 {{< code/copyable >}}
-pack build samples/jar --buildpack gcr.io/paketo-buildpacks/azul-zulu --buildpack paketo-buildpacks/java`
+pack build samples/jar --buildpack paketo-buildpacks/azul-zulu --buildpack paketo-buildpacks/java`
 {{< /code/copyable >}}
 
 There is one drawback to this approach. When using the method above to specify an alternative JVM vendor buildpack, this alternate buildpack ends up running before the CA certs buildpack and therefore traffic from the alternate JVM vendor buildpack won’t trust any additional CA certs. This is not expected to impact many users because JVM buildpacks should reach out to URLs that have a cert signed by a known authority with a CA in the default system truststore.
@@ -244,7 +244,7 @@ If you have customized your JVM buildpack to download the JVM from a URL that us
 For example:
 
 {{< code/copyable >}}
-pack build samples/jar --buildpack paketo-buildpacks/ca-certificates --buildpack gcr.io/paketo-buildpacks/azul-zulu --buildpack paketo-buildpacks/java`
+pack build samples/jar --buildpack paketo-buildpacks/ca-certificates --buildpack paketo-buildpacks/azul-zulu --buildpack paketo-buildpacks/java`
 {{< /code/copyable >}}
 
 It does not hurt to use this command for all situations, it is just more verbose and most users can get away without specifying the CA certificates buildpack to be first.
@@ -325,7 +325,7 @@ The following table documents the versions available.
 For example, to select GraalVM 21.1:
 
 {{< code/copyable >}}
-pack build samples/native -e BP_NATIVE_IMAGE=true --buildpack gcr.io/paketo-buildpacks/ca-certificates --buildpack gcr.io/paketo-buildpacks/java-native-image:5.4.0
+pack build samples/native -e BP_NATIVE_IMAGE=true --buildpack paketo-buildpacks/ca-certificates --buildpack paketo-buildpacks/java-native-image@5.4.0
 {{< /code/copyable >}}
 
 ### Use an Alternative Java Native Image Toolkit

--- a/content/docs/howto/nodejs.md
+++ b/content/docs/howto/nodejs.md
@@ -17,7 +17,7 @@ To build a sample app locally with this buildpack using the pack CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/nodejs/npm
-pack build my-app --buildpack paketobuildpacks/nodejs:latest \
+pack build my-app --buildpack paketo-buildpacks/nodejs \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
@@ -119,7 +119,7 @@ variable, set it to `true`.
 
 {{< code/copyable >}}
 pack build my-app \
-  --buildpack paketobuildpacks/nodejs:latest \
+  --buildpack paketo-buildpacks/nodejs \
   --env BP_NODE_OPTIMIZE_MEMORY=true
 {{< /code/copyable >}}
 
@@ -303,7 +303,7 @@ You can use the Paketo Node.js buildpack with [Tilt][tilt]. This example
 uses the [`pack` extension][tilt/pack] for Tilt.
 {{< code/copyable >}}
 pack('my-app',
-  buildpacks=["paketobuildpacks/nodejs:latest"],
+  buildpacks=["paketo-buildpacks/nodejs"],
   env_vars=["BP_LIVE_RELOAD_ENABLED=true"],
   live_update=[
     sync('.', '/workspace'),

--- a/content/docs/howto/nodejs.md
+++ b/content/docs/howto/nodejs.md
@@ -17,7 +17,7 @@ To build a sample app locally with this buildpack using the pack CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/nodejs/npm
-pack build my-app --buildpack gcr.io/paketo-buildpacks/nodejs \
+pack build my-app --buildpack paketobuildpacks/nodejs:latest \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
@@ -119,7 +119,7 @@ variable, set it to `true`.
 
 {{< code/copyable >}}
 pack build my-app \
-  --buildpack gcr.io/paketo-buildpacks/nodejs \
+  --buildpack paketobuildpacks/nodejs:latest \
   --env BP_NODE_OPTIMIZE_MEMORY=true
 {{< /code/copyable >}}
 
@@ -303,7 +303,7 @@ You can use the Paketo Node.js buildpack with [Tilt][tilt]. This example
 uses the [`pack` extension][tilt/pack] for Tilt.
 {{< code/copyable >}}
 pack('my-app',
-  buildpacks=["gcr.io/paketo-buildpacks/nodejs"],
+  buildpacks=["paketobuildpacks/nodejs:latest"],
   env_vars=["BP_LIVE_RELOAD_ENABLED=true"],
   live_update=[
     sync('.', '/workspace'),

--- a/content/docs/howto/php.md
+++ b/content/docs/howto/php.md
@@ -17,7 +17,7 @@ To build a sample app locally with this CNB using the `pack` CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/php/webserver
-pack build my-app --buildpack paketobuildpacks/php:latest \
+pack build my-app --buildpack paketo-buildpacks/php \
   --builder paketobuildpacks/builder:full
 {{< /code/copyable >}}
 

--- a/content/docs/howto/php.md
+++ b/content/docs/howto/php.md
@@ -17,7 +17,7 @@ To build a sample app locally with this CNB using the `pack` CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/php/webserver
-pack build my-app --buildpack gcr.io/paketo-buildpacks/php \
+pack build my-app --buildpack paketobuildpacks/php:latest \
   --builder paketobuildpacks/builder:full
 {{< /code/copyable >}}
 

--- a/content/docs/howto/python.md
+++ b/content/docs/howto/python.md
@@ -17,7 +17,7 @@ To build a sample app locally with this buildpack using the pack CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/python/pip
-pack build my-app --buildpack paketobuildpacks/python:latest \
+pack build my-app --buildpack paketo-buildpacks/python \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
@@ -135,7 +135,7 @@ You can use the Paketo Python buildpack with [Tilt][tilt]. This example
 uses the [`pack` extension][tilt/pack] for Tilt.
 {{< code/copyable >}}
 pack('my-app',
-  buildpacks=["paketobuildpacks/python:latest"],
+  buildpacks=["paketo-buildpacks/python"],
   env_vars=["BP_LIVE_RELOAD_ENABLED=true"],
   live_update=[
     sync('.', '/workspace'),

--- a/content/docs/howto/python.md
+++ b/content/docs/howto/python.md
@@ -17,7 +17,7 @@ To build a sample app locally with this buildpack using the pack CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/python/pip
-pack build my-app --buildpack gcr.io/paketo-buildpacks/python \
+pack build my-app --buildpack paketobuildpacks/python:latest \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
@@ -135,7 +135,7 @@ You can use the Paketo Python buildpack with [Tilt][tilt]. This example
 uses the [`pack` extension][tilt/pack] for Tilt.
 {{< code/copyable >}}
 pack('my-app',
-  buildpacks=["gcr.io/paketo-buildpacks/python"],
+  buildpacks=["paketobuildpacks/python:latest"],
   env_vars=["BP_LIVE_RELOAD_ENABLED=true"],
   live_update=[
     sync('.', '/workspace'),

--- a/content/docs/howto/ruby.md
+++ b/content/docs/howto/ruby.md
@@ -31,7 +31,7 @@ cd samples/ruby/puma
 
 1. Use the pack CLI with the Paketo Ruby Buildpack to build the sample app.
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/ruby:latest \
+pack build my-app --buildpack paketo-buildpacks/ruby \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
@@ -60,7 +60,7 @@ highest to lowest: `BP_MRI_VERSION`, `Gemfile`.
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_MRI_VERSION` at build time with the `--env` flag.
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/ruby:latest \
+pack build my-app --buildpack paketo-buildpacks/ruby \
   --env BP_MRI_VERSION="2.7.1"
 {{< /code/copyable >}}
 
@@ -111,7 +111,7 @@ location with the following precedence, from highest to lowest:
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_BUNDLER_VERSION` at build time with the `--env` flag.
 {{< code/copyable >}}
-pack build my-app --buildpack paketobuildpacks/ruby:latest \
+pack build my-app --buildpack paketo-buildpacks/ruby \
   --env BP_BUNDLER_VERSION="2.1.4"
 {{< /code/copyable >}}
 

--- a/content/docs/howto/ruby.md
+++ b/content/docs/howto/ruby.md
@@ -31,7 +31,7 @@ cd samples/ruby/puma
 
 1. Use the pack CLI with the Paketo Ruby Buildpack to build the sample app.
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/ruby \
+pack build my-app --buildpack paketobuildpacks/ruby:latest \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 
@@ -60,7 +60,7 @@ highest to lowest: `BP_MRI_VERSION`, `Gemfile`.
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_MRI_VERSION` at build time with the `--env` flag.
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/ruby \
+pack build my-app --buildpack paketobuildpacks/ruby:latest \
   --env BP_MRI_VERSION="2.7.1"
 {{< /code/copyable >}}
 
@@ -111,7 +111,7 @@ location with the following precedence, from highest to lowest:
 #### With pack and a Command-Line Flag
 When building with the pack CLI, set `BP_BUNDLER_VERSION` at build time with the `--env` flag.
 {{< code/copyable >}}
-pack build my-app --buildpack gcr.io/paketo-buildpacks/ruby \
+pack build my-app --buildpack paketobuildpacks/ruby:latest \
   --env BP_BUNDLER_VERSION="2.1.4"
 {{< /code/copyable >}}
 

--- a/content/docs/howto/web-servers.md
+++ b/content/docs/howto/web-servers.md
@@ -26,7 +26,7 @@ To build a sample app locally with this CNB using the `pack` CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/httpd
-pack build my-app --buildpack gcr.io/paketo-buildpacks/httpd \
+pack build my-app --buildpack paketobuildpacks/httpd:latest \
   --builder paketobuildpacks/builder:full
 {{< /code/copyable >}}
 
@@ -82,7 +82,7 @@ To build a sample app locally with this CNB using the `pack` CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/nginx
-pack build my-app --buildpack gcr.io/paketo-buildpacks/nginx \
+pack build my-app --buildpack paketobuildpacks/nginx:latest \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 

--- a/content/docs/howto/web-servers.md
+++ b/content/docs/howto/web-servers.md
@@ -26,7 +26,7 @@ To build a sample app locally with this CNB using the `pack` CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/httpd
-pack build my-app --buildpack paketobuildpacks/httpd:latest \
+pack build my-app --buildpack paketo-buildpacks/httpd \
   --builder paketobuildpacks/builder:full
 {{< /code/copyable >}}
 
@@ -82,7 +82,7 @@ To build a sample app locally with this CNB using the `pack` CLI, run
 {{< code/copyable >}}
 git clone https://github.com/paketo-buildpacks/samples
 cd samples/nginx
-pack build my-app --buildpack paketobuildpacks/nginx:latest \
+pack build my-app --buildpack paketo-buildpacks/nginx \
   --builder paketobuildpacks/builder:base
 {{< /code/copyable >}}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Part of #120 

*Doesn't* change GCR references for buildpacks that aren't currently available on GCR. These include:
- procfile
- azul-zulu
and others.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
