### PR TITLE
Update the way to disable spring cloud bindings

### DIFF
--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -383,7 +383,7 @@ pack inspect-image samples/java --bom | jq '.local[] | select(.name=="dependenci
 
 ### Disable Spring Boot Auto-Configuration
 
-The Spring Boot Buildpack adds [Spring Cloud Bindings][spring cloud bindings] to the application class path. Spring Cloud Bindings will auto-configure the application to connect to an external service when a binding of a supported type provides credentials and connection information at runtime. Runtime auto-configuration is enabled by default but can be disabled with the `BPL_SPRING_CLOUD_BINDINGS_ENABLED` environment variable.
+The Spring Boot Buildpack adds [Spring Cloud Bindings][spring cloud bindings] to the application class path. Spring Cloud Bindings will auto-configure the application to connect to an external service when a binding of a supported type provides credentials and connection information at runtime. Runtime auto-configuration is enabled by default but can be disabled with the `BPL_SPRING_CLOUD_BINDINGS_DISABLED` environment variable at runtime or the `BP_SPRING_CLOUD_BINDINGS_DISABLED` environment variable at build time.
 
 ## Connect to an APM
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The environment variable "BPL_SPRING_CLOUD_BINDINGS_ENABLED" is deprecated and should be removed in reference document. See [https://github.com/paketo-buildpacks/spring-boot](https://github.com/paketo-buildpacks/spring-boot).

The environment variable "BPL_SPRING_CLOUD_BINDINGS_DISABLED" is an alternative at runtime while the environment variable "BP_SPRING_CLOUD_BINDINGS_DISABLED" is another alternative at build time.

## Checklist
<!-- Please confirm the following -->
* [ x ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ x ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ x ] I have added an integration test, if necessary.
* [ x ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ x ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
).
