### PR TITLE
Remove duplicated Getting Started text

### DIFF
--- a/content/getting-started-languages/dotnet_core.md
+++ b/content/getting-started-languages/dotnet_core.md
@@ -167,11 +167,5 @@ curl http://localhost:8080
 
 You can also visit `http://localhost:8080` with your browser to see the app's homepage.
 
-You've done it! As you can see, Paketo buildpacks do most of the hard work for you.
-
-Check out more [sample apps](https://github.com/paketo-buildpacks/samples) that work with Paketo Buildpacks.
-
-Keep reading to learn about Paketo Builders, the Cloud Native Buildpack API, and what Paketo Buildpacks are doing under the hood to make it easy to build your apps.
-
 [install-docker]:https://docs.docker.com/get-docker/
 [install-pack]:https://buildpacks.io/docs/install-pack/

--- a/content/getting-started-languages/java.md
+++ b/content/getting-started-languages/java.md
@@ -195,11 +195,5 @@ curl -s http://localhost:8080/actuator/health | jq .
 }
 {{< /code/output >}}
 
-You've done it! As you can see, Paketo buildpacks do most of the hard work for you.
-
-Check out more [sample apps](https://github.com/paketo-buildpacks/samples) that work with Paketo Buildpacks.
-
-Keep reading to learn about Paketo Builders, the Cloud Native Buildpack API, and what Paketo Buildpacks are doing under the hood to make it easy to build your apps.
-
 [install-docker]:https://docs.docker.com/get-docker/
 [install-pack]:https://buildpacks.io/docs/install-pack/

--- a/content/getting-started-languages/nodejs.md
+++ b/content/getting-started-languages/nodejs.md
@@ -141,11 +141,5 @@ curl http://localhost:8080
 </html>
 {{< /code/output >}}
 
-You've done it! As you can see, Paketo buildpacks do most of the hard work for you.
-
-Check out more [sample apps](https://github.com/paketo-buildpacks/samples) that work with Paketo Buildpacks.
-
-Keep reading to learn about Paketo Builders, the Cloud Native Buildpack API, and what Paketo Buildpacks are doing under the hood to make it easy to build your apps.
-
 [install-docker]:https://docs.docker.com/get-docker/
 [install-pack]:https://buildpacks.io/docs/install-pack/


### PR DESCRIPTION
Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

A short explanation of the proposed change:

Resolves #482.

The "You've done it" text is already present in `/docs/_index.md`, which is the Getting Started page. We don't need to repeat it in the language-family specific content.


Please confirm the following:
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] (For UX change) I have made sure this feature works well on both mobile- and desktop-sized screens.
* [ ] (For UX change) I have followed BEM naming conventions for my CSS (see README).
* [x] (For docs change) I have proofread for spelling, grammar, and accuracy.
* [ ] (For docs change) I have used `{{< ref >}}` and `{{< relref >}}` shortcodes for internal links (see Hugo [docs](https://gohugo.io/content-management/cross-references/)).
* [ ] (For docs change) I have checked that all the links I added point to the intended content.
* [ ] (For docs change) I have tested that all code samples run correctly as written.

