### PR TITLE
Add APM documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@ content/docs/howto/web-servers.md            @paketo-buildpacks/web-servers-main
 content/docs/howto/go.md                     @paketo-buildpacks/go-maintainers
 content/docs/howto/dotnet-core.md            @paketo-buildpacks/dotnet-core-maintainers
 content/docs/howto/configuration.md          @paketo-buildpacks/utilities-maintainers
+content/docs/howto/app-monitor.md            @paketo-buildpacks/app-monitoring-maintainers
 
 content/docs/reference/java-reference.md               @paketo-buildpacks/java-buildpacks
 content/docs/reference/java-native-image-reference.md  @paketo-buildpacks/java-buildpacks

--- a/content/docs/howto/app-monitor.md
+++ b/content/docs/howto/app-monitor.md
@@ -5,13 +5,13 @@ menu:
   main:
     parent: howto
     identifier: monitoring
-    name: "Application Monitoring"
+    name: "Enable Application Monitoring"
 aliases:
   - /docs/buildpacks/app-monitor/
   - /docs/reference/app-monitor/
 ---
 
-This documentation explains how to use the Paketo buildpacks to build applications that include application monitoring tools. 
+This documentation explains how to use the Paketo buildpacks to build applications that include application monitoring tools.
 
 ## Apache Skywalking
 
@@ -225,9 +225,11 @@ Not all of the Paketo Application Monitoring buildpacks are presently included i
 
 We plan to add all of them in the future, but there are presently technical limitations around the maximum number of layers that can be added to the builder preventing more from being added to the builders. What you can do in the meantime is to manually include the APM buildpack that you would like to use at the end of the buildpack list.
 
+<!-- spellchecker-disable -->
 {{< code/copyable >}}
 pack build samples/java --volume "$(pwd)/binding:/platform/bindings/skywalking" -b urn:cnb:builder:paketo-buildpacks/java -b paketo-buildpacks/apache-skywalking
 {{< /code/copyable >}}
+<!-- spellchecker-enable -->
 
 **Note**: it is important to use the `urn:cnb:builder:` reference so that the build uses the composite buildpack that already exists on the builder. If you reference a composite buildpack image, like `gcr.io/paketo-buildpacks/java` or `paketo-buildpacks/java`, this will result in downloading and adding that image to the builder, despite it already being there, which increases the layer count and can make the build fail.
 

--- a/content/docs/howto/app-monitor.md
+++ b/content/docs/howto/app-monitor.md
@@ -1,0 +1,279 @@
+---
+title: "How To Use Application Monitoring With Paketo Buildpacks"
+weight: 341
+menu:
+  main:
+    parent: howto
+    identifier: monitoring
+    name: "Application Monitoring"
+aliases:
+  - /docs/buildpacks/app-monitor/
+  - /docs/reference/app-monitor/
+---
+
+This documentation explains how to use the Paketo buildpacks to build applications that include application monitoring tools. 
+
+## Apache Skywalking
+
+The [Apache Skywalking][apache-skywalking] integration is enabled with [bindings][bindings] through the [Apache Skywalking Buildpack][bp/apache-skywalking]. If a binding of the correct type, `ApacheSkyWalking`, is provided at build-time then an agent appropriate for the application will be contributed to the application image.
+
+Connection credentials will be read from the binding at runtime, with the binding secrets being transformed to system properties with the following the pattern `-Dskywalking.<KEY>=<VALUE>`.
+
+The buildpack supports the Java language.
+
+## AppDynamics
+
+The [AppDynamics][appdynamics] integration is enabled with [bindings][bindings] through the [AppDynamics Buildpack][bp/appdynamics]. If a binding of the correct type, `AppDynamics`, is provided at build-time then an agent appropriate for the application will be contributed to the application image, as well as any required configuration files.
+
+Connection credentials will be read from the binding at runtime, with the binding secrets being transformed to system properties with the following the pattern `APPDYNAMICS_<KEY>=<VALUE>`.
+
+The buildpack supports the Java, Node.js & PHP languages.
+
+## Aternity
+
+The [Aternity][aternity] integration is enabled with [bindings][bindings] through the [Aternity Buildpack][bp/aternity]. If a binding of the correct type, `AppInternals`, is provided at build-time then an agent appropriate for the application will be contributed to the application image.
+
+Connection credentials will be read from the binding at runtime, with the binding secrets being transformed to system properties with the following the pattern `<KEY>=<VALUE>`.
+
+The buildpack supports the Java language.
+
+## Azure Application Insights
+
+The [Azure Application Insights][azure application insights] integration is enabled with [bindings][bindings] through the [Azure Application Insights Buildpack][bp/azure-application-insights]. If a binding of the correct type, `ApplicationInsights`, is provided at build-time then an agent appropriate for the application will be contributed to the application image.
+
+Connection credentials will be read from the binding at runtime, with the binding secrets being transformed to system properties with the following the pattern `APPLICATIONINSIGHTS_<KEY>=<VALUE>`.
+
+The buildpack supports the Java and Node.js languages.
+
+## Datadog
+
+The [Datadog][datadog] integration is enabled by setting an environment variable for the [Datadog Buildpack][bp/datadog]. If the environment variable `BP_DATADOG_ENABLED` is set to a truthy value (i.e. true, t, 1 ignoring case) at build-time then an agent appropriate for the application will be contributed to the application image.
+
+Datadog configuration is read from any of the standard Datadog environment variables that are set at runtime. This happens directly, the buildpack does not translate them. You can find the full list of configuration properties in the Datadog documentation [available here](https://docs.datadoghq.com/tracing/setup_overview/setup/java/?tab=containers#configuration).
+
+The Datadog agent requires a side-car agent to be running in addition to the Java agent. This side-car agent runs outside of the buildpack generated image. The [standard Datadog instructions for your container orchestrator of choice](https://docs.datadoghq.com/tracing/setup_overview/setup/java/?tab=containers#configure-the-datadog-agent-for-apm) can be used to install this agent. The Paketo team also has detailed instructions for [various runtimes available here](https://github.com/paketo-buildpacks/datadog/blob/main/docs/).
+
+The buildpack supports the Java and Node.js languages.
+
+## Dynatrace
+
+The [Dynatrace][dynatrace] integration is enabled with [bindings][bindings] through the [Dynatrace Buildpack][bp/dynatrace]. If a binding of the correct type, `Dynatrace`, is provided at build-time then the Dynatrace OneAgent will be contributed to the application image, and `DT_TENANT`, `DT_TENANTTOKEN`, and `DT_CONNECTION_POINT` are set for launch time.
+
+The binding must include the following required Secret values to successfully contribute Dynatrace:
+
+- Either `api-url`, which is the base URL of the Dynatrace API or `environment-id`, which is a URL is configured in the form: `https://<environment-id>.live.dynatrace.com/api`.
+- An `api-token`, which is the token for communicating with the Dynatrace service.
+
+Any additional configuration information will be read from the binding at runtime, with the binding secrets being transformed to system properties with the following the pattern `DT_<KEY>=<VALUE>`.
+
+The buildpack supports the .NET, Go, Java, NodeJS, and PHP languages, as well as the NGINX and Apache HTTPD servers.
+
+## Elastic APM
+
+The [Elastic APM][elastic apm] integration is enabled with [bindings][bindings] through the [Elastic APM Buildpack][bp/elastic-apm]. If a binding of the correct type, `ElasticAPM`, is provided at build-time then an agent appropriate for the application will be contributed to the application image.
+
+Connection credentials will be read from the binding at runtime, with the binding secrets being transformed to system properties with the following the pattern `ELASTIC_APM_<KEY>=<VALUE>`.
+
+The buildpack supports the Java and Node.js languages.
+
+## Google Stackdriver
+
+The [Google Stackdriver Buildpack][bp/google-stackdriver] has two integrations, a [debugger](https://cloud.google.com/debugger/docs) and a [profiler](https://cloud.google.com/profiler/docs), which are independently installed as requested by the user.
+
+The buildpack supports the Java and Node.js languages.
+
+### Stackdriver Debugger
+
+The Stackdriver Debugger integration is enabled with [bindings][bindings]. If a binding of the correct type, `StackdriverDebugger`, is provided at build-time then an agent appropriate for the application will be contributed to the application image.
+
+The `GOOGLE_APPLICATION_CREDENTIALS` is set to the path of the `ApplicationCredentials` secret.
+
+### Stackdriver Profiler
+
+The Stackdriver Debugger integration is enabled with [bindings][bindings]. If a binding of the correct type, `StackdriverProfiler`, is provided at build-time then an agent appropriate for the application will be contributed to the application image.
+
+The `GOOGLE_APPLICATION_CREDENTIALS` is set to the path of the `ApplicationCredentials` secret.
+
+## JProfiler
+
+The [JProfiler][jprofiler] profiler integration is enabled by setting an environment variable for the [JProfiler Buildpack][bp/jprofiler]. If the environment variable `BP_JPROFILER_ENABLED` is set to a truthy value (i.e. true, t, 1 ignoring case) at build-time then an agent appropriate for the application will be contributed to the application image.
+
+Once contributed to an application image, the JProfiler support can be toggled on/off by setting `BPL_JPROFILER_ENABLED` to a true or false value at runtime. Additionally, `BPL_JPROFILER_PORT` can be set at runtime to customize the port on which the agent listens, defaults to 8849, and `BPL_JPROFILER_NOWAIT` can be set to control if the JVM will execute before JProfiler attaches to the process, defaults to true.
+
+The buildpack supports the Java language.
+
+### Connecting with JProfiler
+
+JProfiler, which runs on your local computer, must connect to a listening port within your container. When starting an application with debugging enabled, a port must be published. 
+
+To publish the port in Docker, use the following command:
+
+{{< code/copyable >}}
+$ docker run --publish <LOCAL_PORT>:<REMOTE_PORT> ...
+{{< /code/copyable >}}
+
+The `REMOTE_PORT` should match the `port` configuration for the application (`8849` by default).  The `LOCAL_PORT` can be any open port on your computer, but typically matches the `REMOTE_PORT` where possible.
+
+Once the port has been published, your JProfiler Profiler, running on your local computer, should connect to `localhost:<LOCAL_PORT>` for profiling.
+
+![JProfiler Configuration](https://raw.githubusercontent.com/paketo-buildpacks/jprofiler/main/jprofiler.png)
+
+## New Relic
+
+The [New Relic][new relic] integration is enabled with [bindings][bindings] through the [New Relic Buildpack][bp/new-relic]. If a binding of the correct type, `NewRelic`, is provided at build-time then an agent appropriate for the application will be contributed to the application image, as well as any required configuration files.
+
+Connection credentials will be read from the binding at runtime, with the binding secrets being transformed to system properties with the following the pattern `NEW_RELIC_<KEY>=<VALUE>`.
+
+The buildpack supports the Java, Node.js and PHP languages.
+
+## YourKit
+
+The [YourKit][yourkit] profiler integration is enabled by setting an environment variable for the [YourKit buildpack][bp/yourkit]. If the environment variable `BP_YOURKIT_ENABLED` is set to a truthy value (i.e. true, t, 1 ignoring case) at build-time then an agent appropriate for the application will be contributed to the application image.
+
+Once contributed to an application image, the JProfiler support can be toggled on/off by setting `BPL_YOURKIT_ENABLED` to a true or false value at runtime. Additionally, `BPL_YOURKIT_PORT` can be set at runtime to customize the port on which the agent listens, defaults to 10001, and `BPL_YOURKIT_SESSION_NAME` can be used to set the session name.
+
+The buildpack supports the Java language.
+
+### Connecting with YourKit
+
+YourKit, which runs on your local computer, must connect to a listening port within your container. When starting an application with debugging enabled, a port must be published. 
+
+To publish the port in Docker, use the following command:
+
+{{< code/copyable >}}
+$ docker run --publish <LOCAL_PORT>:<REMOTE_PORT> ...
+{{< /code/copyable >}}
+
+The `REMOTE_PORT` should match the `port` configuration for the application (`10001` by default).  The `LOCAL_PORT` can be any open port on your computer, but typically matches the `REMOTE_PORT` where possible.
+
+Once the port has been published, your YourKit Profiler, running on your local computer, should connect to `localhost:<LOCAL_PORT>` for profiling.
+
+![YourKit Configuration](https://raw.githubusercontent.com/paketo-buildpacks/yourkit/main/yourkit.png)
+
+## Examples
+
+The following examples show how to use Paketo APM buildpacks with your applications. The examples are broken down into two different types, those that require a binding and those that require an environment variable. Check the buildpack for your APM tool of choice to see if it requires a binding or an environment variable and follow the appropriate instructions.
+
+### Example Prerequisites
+
+Since all of the Paketo application monitoring buildpacks support the Java programming languages we'll use the [Java sample applications][samples/java].
+
+To run the examples, clone the repository and change to the Java sample application directory.
+
+{{< code/copyable >}}
+git clone https://github.com/paketo-buildpacks/samples
+cd samples/java
+{{< /code/copyable >}}
+
+Both of the examples assume that the [Paketo Base builder][base builder] is the default builder. If you haven't already, set it as the default now.
+
+{{< code/copyable >}}
+pack config default-builder paketobuildpacks/builder:base
+{{< /code/copyable >}}
+
+### Example with a Binding
+
+Many of the APM tools require a binding to trigger the tools to be installed and to pass required credentials at runtime. This example uses Azure Application Insights which is one such APM tool.
+
+1. `cd application-insights`.
+2. Build an image with the Azure Application Insights Java Agent:
+
+    {{< code/copyable >}}
+pack build samples/java --volume "$(pwd)/binding:/platform/bindings/application-insights"
+{{< /code/copyable >}}
+
+3. To connect to Azure Application Insights at runtime a valid [Instrumentation Key][azure application insights instrumentation key] is required.
+
+    {{< code/copyable >}}
+echo "<Instrumentation Key>" > binding/InstrumentationKey
+docker run --rm --tty --publish 8080:8080 \
+  --env SERVICE_BINDING_ROOT=/bindings \
+  --volume "$(pwd)/binding:/bindings/app-insights" \
+  samples/java
+{{< /code/copyable >}}
+
+The application should now be running and you can access it with `curl -s http://localhost:8080/actuator/health | jq .` or through your browser. The agent should be collecting and reporting data. Allow time for data to be reported to your APM vendor and check the APM vendor's UI to confirm it's receiving data.
+
+### Example with an Environment Variable
+
+Some of the APM tools require an environment variable to trigger the tools to be installed and only require a binding to pass private credentials at runtime. This example uses Datadog which is one such APM tool.
+
+1. `cd application-insights`.
+2. Build an image with the Datadog Java Agent.
+
+    {{< code/copyable >}}
+pack build samples/java -e BP_DATADOG_ENABLED=true
+{{< /code/copyable >}}
+
+3. Run the Datadog side-car agent. See [Datadog instructions above]({{< ref "#datadog" >}}). This is a specific requirement for Datadog, other APM vendors do not require this.
+
+4. [Configuration of the Datadog agent](https://docs.datadoghq.com/tracing/setup_overview/setup/java/?tab=containers#configuration) is done through environment variables at runtime. Run the application image passing in any required Datadog configuration.
+
+    <!-- spellchecker-disable -->
+    {{< code/copyable >}}
+docker run --rm --tty samples/java -e DD_SERVICE=foo-service -e DD_ENV=foo-env -e DD_VERSION=1.1.1
+{{< /code/copyable >}}
+<!-- spellchecker-enable -->
+
+The application should now be running and you can access it with `curl -s http://localhost:8080/actuator/health | jq .` or through your browser. In addition, the agent should be running now. 
+
+If you're using a profiler, you may connect by following the instructions in the section above for your profiler. If using a reporting agent, it should be collecting and reporting data now. Allow time for data to be reported to your APM vendor and check the APM vendor's UI to confirm it's receiving data. 
+
+### APM Buildpacks with Paketo Builders
+
+Not all of the Paketo Application Monitoring buildpacks are presently included in the Paketo builders. At the moment, the builders include Azure Application Insights, Google Stackdriver, and Datadog.
+
+We plan to add all of them in the future, but there are presently technical limitations around the maximum number of layers that can be added to the builder preventing more from being added to the builders. What you can do in the meantime is to manually include the APM buildpack that you would like to use at the end of the buildpack list.
+
+{{< code/copyable >}}
+pack build samples/java --volume "$(pwd)/binding:/platform/bindings/skywalking" -b urn:cnb:builder:paketo-buildpacks/java -b paketo-buildpacks/apache-skywalking
+{{< /code/copyable >}}
+
+**Note**: it is important to use the `urn:cnb:builder:` reference so that the build uses the composite buildpack that already exists on the builder. If you reference a composite buildpack image, like `gcr.io/paketo-buildpacks/java` or `paketo-buildpacks/java`, this will result in downloading and adding that image to the builder, despite it already being there, which increases the layer count and can make the build fail.
+
+<!-- References -->
+<!-- spellchecker-disable -->
+<!-- buildpacks -->
+[bp/apache-skywalking]:https://github.com/paketo-buildpacks/apache-skywalking
+[bp/appdynamics]:https://github.com/paketo-buildpacks/appdynamics
+[bp/aternity]:https://github.com/paketo-buildpacks/aternity
+[bp/azure-application-insights]:https://github.com/paketo-buildpacks/azure-application-insights
+[bp/datadog]:https://github.com/paketo-buildpacks/datadog
+[bp/dynatrace]:https://github.com/paketo-buildpacks/dynatrace
+[bp/elastic-apm]:https://github.com/paketo-buildpacks/elastic-apm
+[bp/google-stackdriver]:https://github.com/paketo-buildpacks/google-stackdriver
+[bp/jprofiler]:https://github.com/paketo-buildpacks/jprofiler
+[bp/new-relic]:https://github.com/paketo-buildpacks/new-relic
+[bp/yourkit]:https://github.com/paketo-buildpacks/yourkit
+
+<!-- cnb references -->
+[pack]:https://github.com/buildpacks/pack
+[platforms]:https://buildpacks.io/docs/concepts/components/platform/
+
+<!-- paketo references -->
+[bindings]:{{< ref "/docs/howto/configuration#bindings" >}}
+[samples]:https://github.com/paketo-buildpacks/samples
+[samples/java]:https://github.com/paketo-buildpacks/samples/tree/main/java
+
+<!-- paketo docs references -->
+[base builder]:{{< ref "/docs/concepts/builders#base" >}}
+
+<!-- other references -->
+[apm]:https://en.wikipedia.org/wiki/Application_performance_management
+[apache-skywalking]:https://skywalking.apache.org/
+[appdynamics]:https://www.appdynamics.com/
+[aternity]:https://www.aternity.com/application-performance-monitoring/
+[azure application insights instrumentation key]:https://docs.microsoft.com/en-us/azure/azure-monitor/app/create-new-resource#copy-the-instrumentation-key
+[azure application insights]:https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
+[datadog]:https://www.datadoghq.com/
+[dynatrace]:https://www.dynatrace.com/
+[elastic apm]:https://www.elastic.co/observability/application-performance-monitoring
+[google stackdriver]:https://cloud.google.com/products/operations
+[jprofiler]:https://www.ej-technologies.com/products/jprofiler/overview.html
+[new relic]:https://newrelic.com/
+[yourkit]:https://www.yourkit.com/
+[spring boot gradle plugin]:https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/html/#build-image
+[spring boot maven plugin]:https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/html/#build-image
+[spring boot actuator endpoints]:https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints
+
+<!-- spellchecker-enable -->

--- a/content/docs/howto/java.md
+++ b/content/docs/howto/java.md
@@ -457,49 +457,7 @@ The Spring Boot Buildpack adds [Spring Cloud Bindings][spring cloud bindings] to
 
 ## Connect to an APM
 
-The Java Buildpack supports the following [APM][apm] integrations:
-
-* [Azure Application Insights][azure application insights] - support provided by the [Azure Application Insights Buildpack][bp/azure-application-insights]
-* [Google Stackdriver][google stackdriver] - support provided by the [Google Stackdriver Buildpack][bp/google-stackdriver]
-* [Datadog][datadog] - support provided by the [Datadog Buildpack][bp/datadog]
-
-The Azure Application Insights and Google Stackdriver APM integrations are enabled with [bindings][bindings]. If a binding of the correct `type` is provided at build-time the corresponding Java agent will be contributed to the application image. Connection credentials will be read from the binding at runtime.
-
-**Example**: Connecting to Azure Application Insights
-
-The following command builds an image with the Azure Application Insights Java Agent
-{{< code/copyable >}}
-pack build samples/java --volume "$(pwd)/java/application-insights/binding:/platform/bindings/application-insights"
-{{< /code/copyable >}}
-
-To connect to Azure Application Insights at runtime a valid [Instrumentation Key][azure application insights instrumentation key] is required.
-{{< code/copyable >}}
-echo "<Instrumentation Key>" > java/application-insights/binding/InstrumentationKey
-docker run --rm --tty \
-  --env SERVICE_BINDING_ROOT=/bindings \
-  --volume "$(pwd)/java/application-insights/binding:/bindings/app-insights" \
-  samples/java
-{{< /code/copyable >}}
-
-The Datadog APM integration is enabled with an environment variable. If the environment variable is set then the corresponding Java agent will be contributed to the application image. Configuration will be read from standard Datadog environment variables set at runtime. You can find the full list in the Datadog documentation [available here](https://docs.datadoghq.com/tracing/setup_overview/setup/java/?tab=containers#configuration).
-
-**Example**: Connecting to Datadog
-
-The following command builds an image with the Datadog Java Agent
-
-{{< code/copyable >}}
-pack build samples/java -e BP_DATADOG_ENABLED=true
-{{< /code/copyable >}}
-
-[Configuration of the Datadog agent](https://docs.datadoghq.com/tracing/setup_overview/setup/java/?tab=containers#configuration) is done through environment variables at runtime:
-
-<!-- spellchecker-disable -->
-{{< code/copyable >}}
-docker run --rm --tty samples/java -e DD_SERVICE=foo-service -e DD_ENV=foo-env -e DD_VERSION=1.1.1
-{{< /code/copyable >}}
-<!-- spellchecker-enable -->
-
-Note that the Datadog agent requires a side-car agent to be running in addition to the Java agent. This agent runs outside of the buildpack generated image. The [standard Datadog instructions for your container orchestrator of choice](https://docs.datadoghq.com/tracing/setup_overview/setup/java/?tab=containers#configure-the-datadog-agent-for-apm) can be used to install this agent. The Paketo team also has detailed instructions for [various runtimes available here](https://github.com/paketo-buildpacks/datadog/blob/main/docs/).
+Application Monitoring has been moved to a new page. Please see the [Application Monitoring][howto/app-monitor].
 
 ## Enable Process Reloading
 
@@ -764,6 +722,7 @@ Each argument provided to the launcher will be evaluated by the shell prior to e
 [bindings]:{{< ref "/docs/howto/configuration#bindings" >}}
 [build-from-compiled-artifact]:{{< relref "#build-from-a-compiled-artifact" >}}
 [building-from-source]:{{< relref "#build-from-source" >}}
+[howto/app-monitor]:{{< relref "/docs/howto/app-monitor" >}}
 [install-jvm-type]:{{< relref "#install-a-specific-jvm-type" >}}
 [components]:{{< ref "/docs/reference/java-native-image-reference#components" >}}
 [composite buildpack]:{{< ref "/docs/concepts/buildpacks#composite-buildpacks" >}}
@@ -778,14 +737,9 @@ Each argument provided to the launcher will be evaluated by the shell prior to e
 
 <!-- other references -->
 [apache tomcat]:https://tomcat.apache.org
-[apm]:https://en.wikipedia.org/wiki/Application_performance_management
-[azure application insights instrumentation key]:https://docs.microsoft.com/en-us/azure/azure-monitor/app/create-new-resource#copy-the-instrumentation-key
-[azure application insights]:https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
 [bash pattern matching]:https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html
 [dist-zip]:https://docs.gradle.org/current/userguide/distribution_plugin.html
-[datadog]:https://www.datadoghq.com/
 [executable jar]:https://en.wikipedia.org/wiki/JAR_(file_format)#Executable_JAR_files
-[google stackdriver]:https://cloud.google.com/products/operations
 [graalvm feature]:https://www.graalvm.org/sdk/javadoc/org/graalvm/nativeimage/hosted/Feature.html
 [graalvm native image]:https://www.graalvm.org/reference-manual/native-image/
 [graalvm substrate vm]:https://www.graalvm.org/reference-manual/native-image/SubstrateVM/

--- a/scripts/.util/spellcheck-dictionary.txt
+++ b/scripts/.util/spellcheck-dictionary.txt
@@ -17,6 +17,8 @@ APM
 ASP.NET
 Adoptium
 Alibaba
+AppDynamics
+Aternity
 Azul
 BPL_[A-Z_]*(=.*)?
 BP_[A-Z_]*(=.*)?
@@ -45,6 +47,7 @@ Distroless
 Dockerfile(s)?
 Dotnet
 Dragonwell
+Dynatrace
 Entrypoint
 Executable
 Executables
@@ -71,6 +74,7 @@ JDK
 JFR(\-[a-z]+)?
 JLink
 JMX(\-[a-z]+)?
+JProfiler
 JRE
 JSON(\-[a-z]+)?
 JVMKill
@@ -99,6 +103,7 @@ NuGet
 OAuth2
 OCI
 OCI\-[a-z]+
+OneAgent
 OpenJ9
 OpenJDK
 PEM
@@ -116,6 +121,7 @@ Paketo(\-[a-z]+)?
 Pipenv
 Procfile
 Procfiles
+Profiler
 REPL
 Rackup
 Reloadable
@@ -136,6 +142,7 @@ STDIN
 STDOUT
 SaaS
 SapMachine
+Skywalking
 Stackdriver
 Subdirectory
 Syft
@@ -143,6 +150,7 @@ TLS
 TOML
 Tomee
 Trivy
+UI
 URI
 UTF-8
 VM
@@ -151,18 +159,23 @@ Vue
 Watchexec
 Webserver
 Webservers
+YourKit
 [0-9]+M
 [0-9]+MB
 [bB]undler
 [b|B]uildpack\-[p|P]rovided
 [b|B]uildpack\-[s|S]et
 access-bom
+apache-skywalking
 apache-tomcat
 apache-tomee
 api
+apm
+appdynamics
 arg(s)?
 aspnet
 assets:precompile
+aternity
 azul-zulu
 behaviour
 bellsoft-liberica
@@ -224,6 +237,8 @@ dotnet-core-sdk:dotnet-env-var
 dotnet-execute
 dotnet-publish
 dotnet-publish-output295991778
+dynatrace
+elastic-apm
 entrypoint
 env
 env-vars
@@ -259,6 +274,7 @@ ioutil
 jattach
 javascript-frontend
 jdk
+jprofiler
 jq
 jre
 jvmkill
@@ -325,6 +341,7 @@ prepending
 prepends
 procfile
 procfiles
+profiler
 read-eval-print
 redownloaded
 reference_docs_path
@@ -350,6 +367,7 @@ toolchain
 totalling
 trivy
 truststore
+truthy
 tty
 ubuntu:bionic
 unicode
@@ -364,3 +382,4 @@ watchexec
 webserver
 webservers
 yarnrc
+yourkit


### PR DESCRIPTION
This PR makes two changes:

1. It adds a dedicated section for documentation around the APM tools buildpacks. This provides instructions for each supported APM integration, as well as two general examples for using the APM tools buildpacks.
2. It removes the section under the Java docs, which previously had APM instructions, and references the newly created APM docs section.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
