### PR TITLE
Document Angular + readonly filesystem workaround

### DIFF
--- a/content/docs/howto/nodejs.md
+++ b/content/docs/howto/nodejs.md
@@ -178,6 +178,34 @@ $BP_NODE_RUN_SCRIPTS=lint,build
 then the `lint` and then `build` scripts would be run via npm or yarn, during build phase. Note that the 
 value for `BP_NODE_RUN_SCRIPTS` must be a comma separated list of script names.
 
+
+## Build Angular apps on stacks with read-only filesystems
+By default, when an Angular app starts up, it attempts to create a cache,
+`.angular/cache`, in the app's directory. On some stacks, (including the Paketo
+Jammy stacks) the app directory is read-only at runtime.  As a result, Angular
+apps will fail to start with errors like ` Error: EACCES: permission denied,
+open '/workspace/.angular/cache`.
+
+To avoid this failure, configure Angular to create the cache in a writeable
+location, like `/tmp`.
+
+### Setting an Angular cache path in `angular.json`
+To configure the location of the Angular cache, set the `cli.cache.path`
+parameter in your app's `angular.json`. Add the following snippet to your
+`angular.json`:
+
+{{< code/copyable >}}
+  "cli":{
+    "cache": {
+      "path": "/tmp/.angular/cache"
+    }
+  },
+{{< /code/copyable >}}
+
+With this setting, the Angular app will start successfully and write cache
+artifacts to the `/tmp` directory.
+
+
 ## Build an App that Uses NPM
 The Node.js buildpack can detect automatically if an app requires `npm`.
 

--- a/content/docs/howto/nodejs.md
+++ b/content/docs/howto/nodejs.md
@@ -179,7 +179,7 @@ then the `lint` and then `build` scripts would be run via npm or yarn, during bu
 value for `BP_NODE_RUN_SCRIPTS` must be a comma separated list of script names.
 
 
-## Build Angular apps on stacks with read-only filesystems
+## Build Angular apps on stacks with read-only file systems
 By default, when an Angular app starts up, it attempts to create a cache,
 `.angular/cache`, in the app's directory. On some stacks, (including the Paketo
 Jammy stacks) the app directory is read-only at runtime.  As a result, Angular

--- a/scripts/.util/spellcheck-dictionary.txt
+++ b/scripts/.util/spellcheck-dictionary.txt
@@ -383,5 +383,6 @@ vendoring
 watchexec
 webserver
 webservers
+writeable
 yarnrc
 yourkit


### PR DESCRIPTION
Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

A short explanation of the proposed change:
* Resolves #539

I chose to include an example of the failure output because that'll hopefully help users find the documentation if they search for their error on our site.  The resolution is modeled after the changes in [the angular sample app](https://github.com/paketo-buildpacks/samples/blob/d8fbbe6cf803264c85ba3adafb311febaa85814e/nodejs/angular-npm/angular.json).


Please confirm the following:
* [x] I have viewed, signed, and submitted the Contributor License Agreement.

* [ ] (For UX change) I have made sure this feature works well on both mobile- and desktop-sized screens.
* [ ] (For UX change) I have followed BEM naming conventions for my CSS (see README).

* [x] (For docs change) I have proofread for spelling, grammar, and accuracy.
* [ ] (For docs change) I have used `{{< ref >}}` and `{{< relref >}}` shortcodes for internal links (see Hugo [docs](https://gohugo.io/content-management/cross-references/)).
* [ ] (For docs change) I have checked that all the links I added point to the intended content.
* [x] (For docs change) I have tested that all code samples run correctly as written.

