### PR TITLE
Replace deprecated GHA ::set-output syntax

### DIFF
--- a/.github/workflows/deploy-dev-pr.yml
+++ b/.github/workflows/deploy-dev-pr.yml
@@ -30,7 +30,7 @@ jobs:
       id: hugo-version
       run: |
         version=$(jq -r .hugo "scripts/.util/tools.json")
-        echo "::set-output name=version::${version#v}"
+        echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
     - name: Checkout PR
       if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -31,7 +31,7 @@ jobs:
       id: hugo-version
       run: |
         version=$(jq -r .hugo "build-environment/scripts/.util/tools.json")
-        echo "::set-output name=version::${version#v}"
+        echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2
@@ -57,7 +57,7 @@ jobs:
         if [[ -n "$(git status --short)" ]]; then
           git add --all .
           git commit --message "Deploying"
-          echo "::set-output name=commit_sha::$(git rev-parse HEAD)"
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Push

--- a/deploy.js
+++ b/deploy.js
@@ -1,4 +1,5 @@
-firebase = require('firebase-tools');
+const firebase = require('firebase-tools');
+const core = require('@actions/core');
 
 module.exports = async ({ expires } = { expires: '1h'}) => {
   const { GITHUB_HEAD_REF } = process.env;
@@ -18,8 +19,8 @@ module.exports = async ({ expires } = { expires: '1h'}) => {
     .then((data) => {
       console.log(`PR DEPLOYED TO: ${data['paketo-stage'].url}`)
       console.log(`SITE EXPIRES AT: ${data['paketo-stage'].expireTime} (in ${expires})`)
-      console.log(`::set-output name=staging_url::${data['paketo-stage'].url}`)
-      console.log(`::set-output name=expiration::${data['paketo-stage'].expireTime} (in ${expires})`)
+      core.setOutput("staging_url", data['paketo-stage'].url);
+      core.setOutput("expiration", `${data['paketo-stage'].expireTime} (in ${expires})`);
     })
     .catch((err) => {
       console.log(`deploy: ${err}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,30 @@
   "packages": {
     "": {
       "dependencies": {
+        "@actions/core": "^1.10.0",
         "@docsearch/js": "^3.3.2",
         "clipboard": "^2.0.11",
         "firebase-tools": "^11.22.0"
       },
       "devDependencies": {
         "spellchecker-cli": "^6.1.1"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -9886,6 +9904,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/typical": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
@@ -10058,6 +10084,14 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/uvu": {
@@ -10270,6 +10304,23 @@
     }
   },
   "dependencies": {
+    "@actions/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "requires": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "requires": {
+        "tunnel": "^0.0.6"
+      }
+    },
     "@algolia/autocomplete-core": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.4.tgz",
@@ -17778,6 +17829,11 @@
       "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
       "dev": true
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
     "typical": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
@@ -17907,6 +17963,11 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "uvu": {
       "version": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@actions/core": "^1.10.0",
     "@docsearch/js": "^3.3.2",
     "clipboard": "^2.0.11",
     "firebase-tools": "^11.22.0"


### PR DESCRIPTION
## Summary

Use the new way of producing outputs in a github action as the old way is deprecated and will be removed (31st May 2023).

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

See also: https://github.com/paketo-buildpacks/github-config/pull/604

## Use Cases

Keep the pipelines alive.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
