### PR TITLE
nodejs/node-gyp: rm outdated requirement for full builder

### DIFF
--- a/content/docs/howto/nodejs.md
+++ b/content/docs/howto/nodejs.md
@@ -260,11 +260,6 @@ pack build myapp \
     --volume <absolute-path-to-binding-dir>:/bindings/yarnrc
 {{< /code/copyable >}}
 
-## Compile Native Extensions with `node-gyp`
-If your app requires compilation of native extensions using `node-gyp`, the Node.js buildpack requires that
-you use the Paketo Full Builder. This is because `node-gyp` requires `python` which is excluded from
-the Paketo Base Builder's stack, and the module may require other shared objects.
-
 ### With pack and a Command-Line Flag
 When building with the pack CLI, specify the latest Paketo Full Builder at build time
 with the `--builder` flag.


### PR DESCRIPTION
Python has been in the base builder(s) for a while now. See https://github.com/paketo-buildpacks/base-builder/commit/0d87223d9bf854316c36eb76dbbcd6e8dc6a3a63

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
