### PR TITLE
Update github search in community page to include more labels.

### DIFF
--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -101,8 +101,8 @@ written by members of the Paketo community to propose technical changes to the p
 <h2>Contributing</h2>
 <p class="body">
 Check out our <a href="https://github.com/paketo-buildpacks/.github/blob/main/CONTRIBUTING.md">contribution guide</a> for an idea of where to begin.
-You may wish to start with issues labeled <a href="https://github.com/search?q=org%3Apaketo-buildpacks+org%3Apaketo-community+label%3A%22good+first+issue%22+state%3Aopen&type=Issues"><code>good first issue</code></a>
-or <a href="https://github.com/search?q=org%3Apaketo-buildpacks+org%3Apaketo-community+label%3A%22help+wanted%22+state%3Aopen&type=Issues"><code>help wanted</code></a>.
+You may wish to start with issues labeled <a href="https://github.com/search?q=org%3Apaketo-buildpacks+org%3Apaketo-community+label%3A%22good+first+issue%22%2C%22note%3Agood-first-issue%22+state%3Aopen+&type=Issues"><code>good first issue</code></a>
+or <a href="https://github.com/search?q=org%3Apaketo-buildpacks+org%3Apaketo-community+label%3A%22help+wanted%22%2C%22note%3Aideal-for-contribution%22+state%3Aopen+&type=Issues"><code>help wanted</code></a>.
 </p>
 <h2>Signing the CLA</h2>
 <p class="body">


### PR DESCRIPTION
## Summary / Use Cases

Following on from #651 , this PR adds the `note:good-first-issue` and `note:ideal-for-contribution` labels to the links on the community page. These are the labels used by the Java buildpacks (and others, like ca-certificates).

We have decided to punt the conversation about unifiying the labels across all repos, but adding both sets to the links allows them all to be discovered easily in one place.

This is in service of: https://github.com/paketo-buildpacks/community/issues/127

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
