### PR TITLE
Update Project Descriptor to latest spec

### DIFF
--- a/content/docs/howto/dotnet-core.md
+++ b/content/docs/howto/dotnet-core.md
@@ -59,7 +59,10 @@ pack build myapp --env BP_DOTNET_FRAMEWORK_VERSION=5.0.4
 
 #### In a `project.toml` file
 {{< code/copyable >}}
-[[ build.env ]]
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
   name = 'BP_DOTNET_FRAMEWORK_VERSION'
   value = '5.0.4'
 {{< /code/copyable >}}
@@ -201,7 +204,10 @@ pack build my-app --env BP_DOTNET_PROJECT_PATH=./App
 
 #### In a `project.toml` file
 {{< code/copyable >}}
-[[ build.env ]]
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
   name = 'BP_DOTNET_PROJECT_PATH'
   value = './App'
 {{< /code/copyable >}}
@@ -230,8 +236,10 @@ pack build my-app --buildpack paketo-buildpacks/dotnet-core \
 When building with the pack CLI, create a [project.toml][cnb/project-file] file in your app directory that sets `BP_DOTNET_PUBLISH_FLAGS` at build time. For example, to add `--verbosity=normal` and `--self-contained=true` to the build flagset, set the environment variable as follows:
 {{< code/copyable >}}
 # project.toml
-[ build ]
-  [[ build.env ]]
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
     name="BP_DOTNET_PUBLISH_FLAGS"
     value="--verbosity=normal --self-contained=true"
 {{< /code/copyable >}}
@@ -287,7 +295,10 @@ pack build myapp --env BP_LIVE_RELOAD_ENABLED=true
 
 #### In a `project.toml` file
 {{< code/copyable >}}
-[[ build.env ]]
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
   name = 'BP_LIVE_RELOAD_ENABLED'
   value = 'true'
 {{< /code/copyable >}}
@@ -369,7 +380,10 @@ pack build myapp --env BP_DEBUG_ENABLED=true
 #### In a `project.toml` file
 <!-- spellchecker-disable -->
 {{< code/copyable >}}
-[[ build.env ]]
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
   name = 'BP_DEBUG_ENABLED'
   value = 'true'
 {{< /code/copyable >}}

--- a/content/docs/howto/go.md
+++ b/content/docs/howto/go.md
@@ -60,10 +60,12 @@ pack build my-app --buildpack paketo-buildpacks/go \
 When building with the pack CLI, create a [project.toml][cnb/project-file] file in your app directory that sets `BP_GO_VERSION` at build time.
 {{< code/copyable >}}
 # project.toml
-[ build ]
-  [[ build.env ]]
-    name="BP_GO_VERSION"
-    value="1.14.1"
+[ _ ]
+schema-version = "0.2
+
+[[ io.buildpacks.build.env ]]
+  name="BP_GO_VERSION"
+  value="1.14.1"
 {{< /code/copyable >}}
 
 
@@ -88,10 +90,12 @@ pack build my-app --buildpack paketo-buildpacks/go \
 When building with the pack CLI, create a [project.toml][cnb/project-file] file in your app directory that sets `BP_GO_BUILD_LDFLAGS` at build time. For example, to add `-ldflags="-X main.variable=some-value"` to the build flagset, set the environment variable as follows:
 {{< code/copyable >}}
 # project.toml
-[ build ]
-  [[ build.env ]]
-    name="BP_GO_BUILD_LDFLAGS"
-    value="-X main.variable=some-value"
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
+  name="BP_GO_BUILD_LDFLAGS"
+  value="-X main.variable=some-value"
 {{< /code/copyable >}}
 
 The pack CLI will automatically detect the project file at build time.
@@ -110,10 +114,12 @@ pack build my-app --buildpack paketo-buildpacks/go \
 When building with the pack CLI, create a [project.toml][cnb/project-file] file in your app directory that sets `BP_GO_BUILD_FLAGS` at build time. For example, to add `-buildmode=default -tags=paketo` to the build flagset, set the environment variable as follows:
 {{< code/copyable >}}
 # project.toml
-[ build ]
-  [[ build.env ]]
-    name="BP_GO_BUILD_FLAGS"
-    value="-buildmode=default -tags=paketo"
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
+  name="BP_GO_BUILD_FLAGS"
+  value="-buildmode=default -tags=paketo"
 {{< /code/copyable >}}
 
 The pack CLI will automatically detect the project file at build time.
@@ -146,10 +152,12 @@ pack build my-app --buildpack paketo-buildpacks/go \
 When building with the pack CLI, create a [project.toml][cnb/project-file] file in your app directory that sets `BP_GO_TARGETS` at build time.
 {{< code/copyable >}}
 # project.toml
-[ build ]
-  [[ build.env ]]
-    name="BP_GO_TARGETS"
-    value="./second"
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
+  name="BP_GO_TARGETS"
+  value="./second"
 {{< /code/copyable >}}
 
 The pack CLI will automatically detect the project file at build time.
@@ -172,10 +180,12 @@ pack build my-app --buildpack paketo-buildpacks/go \
 When building with the pack CLI, create a [project.toml][cnb/project-file] file in your app directory that sets `BP_GO_TARGETS` at build time.
 {{< code/copyable >}}
 # project.toml
-[ build ]
-  [[ build.env ]]
-    name="BP_GO_TARGETS"
-    value="./first:./second"
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
+  name="BP_GO_TARGETS"
+  value="./first:./second"
 {{< /code/copyable >}}
 
 ## Import Private Go Modules
@@ -250,10 +260,12 @@ pack build my-app --buildpack paketo-buildpacks/go \
 When building with the pack CLI, create a [project.toml][cnb/project-file] file in your app directory that sets `$BP_GO_BUILD_IMPORT_PATH` at build time.
 {{< code/copyable >}}
 # project.toml
-[ build ]
-  [[ build.env ]]
-    name="BP_GO_BUILD_IMPORT_PATH"
-    value="github.com/app-developer/app-directory"
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
+  name="BP_GO_BUILD_IMPORT_PATH"
+  value="github.com/app-developer/app-directory"
 {{< /code/copyable >}}
 
 ## Prevent Source Files From Being Deleted
@@ -278,10 +290,12 @@ pack build my-app --buildpack paketo-buildpacks/go \
 When building with the pack CLI, create a [project.toml][cnb/project-file] file in your app directory that sets `$BP_KEEP_FILES` at build time.
 {{< code/copyable >}}
 # project.toml
-[ build ]
-  [[ build.env ]]
-    name="BP_KEEP_FILES"
-    value="assets/*:public/*"
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
+  name="BP_KEEP_FILES"
+  value="assets/*:public/*"
 {{< /code/copyable >}}
 
 ## Enable Process Reloading
@@ -306,7 +320,10 @@ pack build myapp --env BP_LIVE_RELOAD_ENABLED=true
 
 #### In a `project.toml` file
 {{< code/copyable >}}
-[[ build.env ]]
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
   name = 'BP_LIVE_RELOAD_ENABLED'
   value = 'true'
 {{< /code/copyable >}}

--- a/content/docs/howto/nodejs.md
+++ b/content/docs/howto/nodejs.md
@@ -323,7 +323,10 @@ pack build myapp --env BP_LIVE_RELOAD_ENABLED=true
 
 #### In a `project.toml` file
 {{< code/copyable >}}
-[[ build.env ]]
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
   name = 'BP_LIVE_RELOAD_ENABLED'
   value = 'true'
 {{< /code/copyable >}}

--- a/content/docs/howto/python.md
+++ b/content/docs/howto/python.md
@@ -41,10 +41,12 @@ a [`project.toml`](https://buildpacks.io/docs/app-developer-guide/using-project-
 as shown in the following example:
 
 {{< code/copyable >}}
-[build]
-  [[build.env]]
-    name = "BP_CPYTHON_VERSION"
-    value = "3.6.*" # any valid semver constraints (e.g. 3.6.7, 3.*) are acceptable
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
+  name = "BP_CPYTHON_VERSION"
+  value = "3.6.*" # any valid semver constraints (e.g. 3.6.7, 3.*) are acceptable
 {{< /code/copyable >}}
 
 Specifying a version of CPython is not required. In the case this is not
@@ -144,7 +146,10 @@ pack build myapp --env BP_LIVE_RELOAD_ENABLED=true
 
 #### In a `project.toml` file
 {{< code/copyable >}}
-[[ build.env ]]
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
   name = 'BP_LIVE_RELOAD_ENABLED'
   value = 'true'
 {{< /code/copyable >}}

--- a/content/docs/howto/ruby.md
+++ b/content/docs/howto/ruby.md
@@ -69,10 +69,12 @@ When building with the pack CLI, create a [project.toml][cnb/project-file] file
 in your app directory that sets `BP_MRI_VERSION` at build time.
 {{< code/copyable >}}
 # project.toml
-[ build ]
-  [[ build.env ]]
-    name="BP_MRI_VERSION"
-    value="2.7.1"
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
+  name="BP_MRI_VERSION"
+  value="2.7.1"
 {{< /code/copyable >}}
 
 The pack CLI will automatically detect the project file at build time.
@@ -120,10 +122,12 @@ When building with the pack CLI, create a [project.toml][cnb/project-file] file
 in your app directory that sets `BP_BUNDLER_VERSION` at build time.
 {{< code/copyable >}}
 # project.toml
-[ build ]
-  [[ build.env ]]
-    name="BP_BUNDLER_VERSION"
-    value="2.1.4"
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
+  name="BP_BUNDLER_VERSION"
+  value="2.1.4"
 {{< /code/copyable >}}
 
 The pack CLI will automatically detect the project file at build time.


### PR DESCRIPTION
Use the latest specification of project.toml file.  This requires a schema-version property of the [_] table, which we default to the current latest version of "0.2"

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
The upstream buildpacks.io docs have updated to use the latest version of the project.toml spec.  Reflecting those updates here will hopefully help to reduce end-user confusion.

## Use Cases
People who read the documentation will now find that buildpacks.io and paketo document the same version of project.toml.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
