### PR TITLE
Make steering committee memebers co-owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*                                            @paketo-buildpacks/content-maintainers
+*                                            @paketo-buildpacks/content-maintainers @paketo-buildpacks/steering-committee
 
 content/getting-started-languages/java.md         @paketo-buildpacks/java-buildpacks
 content/getting-started-languages/nodejs.md       @paketo-buildpacks/nodejs-maintainers


### PR DESCRIPTION
## Summary

Allows @paketo-buildpacks/steering-committee to be co-owners of this repository.

## Use Cases

Steering Committee members often contribute to the website. It helps if we can review & merge.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
