### PR TITLE
How-to regarding dependency mirrors added

### DIFF
--- a/content/docs/howto/configuration.md
+++ b/content/docs/howto/configuration.md
@@ -252,6 +252,13 @@ For example, to make the BellSoft Liberica JRE dependency accessible available t
    * A key/value pair where the key is equal to the `sha256` of the dependency and the value is equal to the new URI.
 4. Configure all builds with this binding.
 
+### Dependency Mirrors
+The above mentioned [dependency mappings](#dependency-mappings) serve best for mapping a specific version of a dependency to a location reachable within an air-gapped environment.
+
+Larger (corporate) networks might have a central mirror server available to cache dependencies for access from within the local network. Dependency mirrors can be used to download all (or some) buildpack dependencies from such alternative locations regardless of their versions.
+
+<< WORK IN PROGRESS >>
+
 ## CA Certificates
 
 Additional CA certificates may be added to the system truststore using the [Paketo CA Certificates Buildpack][bp/ca-certificates].

--- a/content/docs/howto/configuration.md
+++ b/content/docs/howto/configuration.md
@@ -253,7 +253,7 @@ For example, to make the BellSoft Liberica JRE dependency accessible available t
 4. Configure all builds with this binding.
 
 ### Dependency Mirrors
-Larger (corporate) networks might have a mirror server available to cache dependencies for access from within the local network. Dependency mirrors can be used to download all (or some) buildpack dependencies from such alternative locations regardless of their versions.
+Larger networks might have a mirror server available to cache dependencies for access from within the local network. Dependency mirrors can be used to download buildpack dependencies from such alternative locations regardless of their versions.
 
 If dependency mirrors and dependency mappings are defined at the same time, those artifacts specifically mapped as described in [Dependency Mappings]({{< relref "#dependency-mappings" >}}) are loaded accordingly. All other dependencies are downloaded from the mirror, should one apply.
 

--- a/content/docs/howto/configuration.md
+++ b/content/docs/howto/configuration.md
@@ -299,14 +299,35 @@ This can be handy in case dependencies from the original host A must be download
 
 Special attention needs to be paid when setting hostname specific mirrors using environment variables due to naming restrictions.  
 Dots (`.`) of the original hostname must be replaced with a single underscore (`_`) whilst dashes (`-`) are replaced with a double underscore (`__`).  
-In the below example, dependencies with `github.com` as their hostname in the original location would be downloaded from `https://mirror.example.org/public-github`, dependencies with hostname `download.bell-sw.com` from `https://mirror.example.org/bell-sw`, and all others from `https://mirror.example.org/{originalHost}`.
 
+**Example**
+Let's assume a buildpack relies on three dependencies from these original locations:
+1) `https://github.com/bell-sw/Liberica/releases/download/11.0.8+10/bellsoft-jre11.0.8+10-linux-amd64.tar.gz`
+2) `https://download.bell-sw.com/vm/22.3.5/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-linux-amd64.tar.gz`
+3) `https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.tar.gz`
+Two scenarios using a hostname mirror can be thought of.
+
+**Scenario A: Hostname Mirror(s) only**  
+If hostname specific mirrors are defined for `github.com` and `download.bell-sw.com` only as in:
+```
+BP_DEPENDENCY_MIRROR_GITHUB_COM             https://mirror.example.org/public-github
+BP_DEPENDENCY_MIRROR_DOWNLOAD_BELL__SW_COM  https://mirror.example.org/bell-sw
+```
+The URI of dependency 1 would be transformed to: `https://mirror.example.org/public-github/bell-sw/Liberica/releases/download/11.0.8+10/bellsoft-jre11.0.8+10-linux-amd64.tar.gz`.  
+The URI of dependency 2 would be changed to `https://mirror.example.org/bell-sw/vm/22.3.5/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-linux-amd64.tar.gz`.  
+The URI of dependency 3 would stay unchanged and downloads would be made from the original location.
+
+**Scenario B: Hostname Mirror(s) with Default Mirror**  
+If we add a default mirror to scenario A like this:
 ```
 BP_DEPENDENCY_MIRROR                        https://mirror.example.org/{originalHost}
 BP_DEPENDENCY_MIRROR_GITHUB_COM             https://mirror.example.org/public-github
 BP_DEPENDENCY_MIRROR_DOWNLOAD_BELL__SW_COM  https://mirror.example.org/bell-sw
 ```
+The download URIs of dependencies 1 and 2 would be translated like before.  
+But since there is a default mirror defined, which acts for all other hostnames, dependency 3 would be downloaded from `https://mirror.example.org/repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.tar.gz`, rather than from it's original location.
 
+**Hostname Mirrors from Bindings**  
 When using bindings to set hostname specific mirrors, their keys must match the original URI's hostname. E.g.:
 ```
 /platform
@@ -317,7 +338,6 @@ When using bindings to set hostname specific mirrors, their keys must match the 
             ├── download.bell-sw.com        https://mirror.example.org/bell-sw
             └── type                        dependency-mirror
 ```
-If no default mirror is set, dependencies not matching any mirror, are downloaded from their original public location.
 
 ## CA Certificates
 


### PR DESCRIPTION
## Summary
This adds the documentation on how to configure Paketo Buildpacks to use dependency mirrors as described in [RFC 0060](https://github.com/paketo-buildpacks/rfcs/blob/11691011512b9f075d06c31b74ea29bb5c3e5f69/text/0060-dependency-mirrors.md) 

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
