### PR TITLE
Fix typo in path for runtime ca certs binding example.

### DIFF
--- a/content/docs/howto/configuration.md
+++ b/content/docs/howto/configuration.md
@@ -377,7 +377,7 @@ Run the sample application, providing the binding, and passing the URL as a posi
 ```bash
 docker run --rm \
   --env SERVICE_BINDING_ROOT=/bindings \
-  --volume "$(pwd)/ca-certficates/binding:/bindings/ca-certificates" \
+  --volume "$(pwd)/ca-certificates/binding:/bindings/ca-certificates" \
   samples/ca-certificates <url>
 ```
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
