### PR TITLE
Fix slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ dictionary is usually preferred.
       staging URL.
 * Join website-related conversations in the
   [#website](https://paketobuildpacks.slack.com/archives/C0229DVMFM5) channel
-  of the [Paketo slack instance](https://slack.paketo.io/).
+  of the [Paketo slack instance](https://join.slack.com/t/paketobuildpacks/shared_invite/zt-2jayv12ro-eTP8AtcmvyIpEtlANfIb~g).
 
 ## Deployment
 This repo uses a GHA workflow to automatically deploy commits on `main` to the

--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -20,7 +20,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 <section class="homepage-section homepage-section--dark community-action-section">
 <div class="community-action-container">
-<a class="action-button" href="https://slack.paketo.io/">
+<a class="action-button" href="https://join.slack.com/t/paketobuildpacks/shared_invite/zt-2jayv12ro-eTP8AtcmvyIpEtlANfIb~g">
 <div class="action-button__content">
 <div class="action-button__image-container">
 <div class="logo">


### PR DESCRIPTION
* default slack.paketo.io is no longer working, probably since the slack account was transferred back to CloudFoundry Foundation
* use the invite link everywhere, it's valid

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
