### PR TITLE
Update java-native-image-reference.md

### DIFF
--- a/content/docs/reference/java-native-image-reference.md
+++ b/content/docs/reference/java-native-image-reference.md
@@ -55,6 +55,7 @@ The following component buildpacks compose the Paketo Java Native Image Buildpac
 [bp/sbt]:https://github.com/paketo-buildpacks/sbt
 [bp/spring-boot]:https://github.com/paketo-buildpacks/spring-boot
 [bp/native-image]:https://github.com/paketo-buildpacks/spring-boot-native-image
+[bp/java-native-image]:https://github.com/paketo-buildpacks/java-native-image
 
 [samples]:https://github.com/paketo-buildpacks/samples
 


### PR DESCRIPTION
## Summary
Fix hyperlink to Paketo Java Native Image Buildpack repository under "Java Native Image Buildpack Reference" page.

![obraz](https://github.com/user-attachments/assets/448dfcde-b021-4958-a851-31a709120c20)

## Use Cases
N/A

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
